### PR TITLE
feat(typescript): typescript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,18733 @@
 {
   "name": "@octokit/plugin-enterprise-server",
   "version": "0.0.0-development",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@octokit/plugin-enterprise-server",
+      "version": "0.0.0-development",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.17.0"
+      },
+      "devDependencies": {
+        "@octokit/core": "^3.0.0",
+        "@pika/pack": "^0.5.0",
+        "@pika/plugin-build-node": "^0.9.0",
+        "@pika/plugin-build-web": "^0.9.0",
+        "@pika/plugin-ts-standard-pkg": "^0.9.0",
+        "@types/fetch-mock": "^7.3.2",
+        "@types/jest": "^26.0.0",
+        "@types/node": "^14.0.4",
+        "fetch-mock": "^9.0.0",
+        "github-openapi-graphql-query": "^1.0.5",
+        "jest": "^27.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "2.3.2",
+        "semantic-release": "^17.0.0",
+        "semantic-release-plugin-update-version-in-files": "^1.0.0",
+        "sort-keys": "^4.2.0",
+        "string-to-jsdoc-comment": "^1.0.0",
+        "ts-jest": "^27.0.0-next.12",
+        "typescript": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@ardatan/aggregate-error": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
+      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/aggregate-error/node_modules/tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+      "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
+      "dev": true
+    },
+    "node_modules/@babel/core": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+      "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.14.3",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-module-transforms": "^7.14.2",
+        "@babel/helpers": "^7.14.0",
+        "@babel/parser": "^7.14.3",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.2",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz",
+      "integrity": "sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz",
+      "integrity": "sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-explode-assignable-expression": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.15",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.3.tgz",
+      "integrity": "sha512-BnEfi5+6J2Lte9LeiL6TxLWdIlEv9Woacc1qXzXBgbikcOzMRM2Oya5XGg/f/ngotv1ej2A/b+3iJH8wbS1+lQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "@babel/helper-function-name": "^7.14.2",
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.14.3",
+        "@babel/helper-split-export-declaration": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.3.tgz",
+      "integrity": "sha512-JIB2+XJrb7v3zceV2XzDhGIB902CmKGSpSl4q2C6agU9SNLG/2V1RtFRGPG1Ajh9STj3+q6zJMOC+N/pp2P9DA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "regexpu-core": "^4.7.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
+      }
+    },
+    "node_modules/@babel/helper-explode-assignable-expression": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz",
+      "integrity": "sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+      "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.14.2"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz",
+      "integrity": "sha512-1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.13.15",
+        "@babel/types": "^7.13.16"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+      "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz",
+      "integrity": "sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "@babel/helper-wrap-function": "^7.13.0",
+        "@babel/types": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+      "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+      "integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz",
+      "integrity": "sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+      "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.14.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+      "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.2.tgz",
+      "integrity": "sha512-b1AM4F6fwck4N8ItZ/AtC4FP/cqZqmKRQ4FaTDutwSYyjuhtvsGEMLK4N/ztV/ImP40BjIDyMgBQAeAMsQYVFQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-remap-async-to-generator": "^7.13.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-class-properties": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
+      "integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-class-static-block": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.3.tgz",
+      "integrity": "sha512-HEjzp5q+lWSjAgJtSluFDrGGosmwTgKwCXdDQZvhKsRlwv3YdkUEqxNrrjesJd+B9E9zvr1PVPVBvhYZ9msjvQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.14.3",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-class-static-block": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-dynamic-import": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.2.tgz",
+      "integrity": "sha512-oxVQZIWFh91vuNEMKltqNsKLFWkOIyJc95k2Gv9lWVyDfPUQGSSlbDEgWuJUU1afGE9WwlzpucMZ3yDRHIItkA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.2.tgz",
+      "integrity": "sha512-sRxW3z3Zp3pFfLAgVEvzTFutTXax837oOatUIvSG9o5gRj9mKwm3br1Se5f4QalTQs9x4AzlA/HrCWbQIHASUQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-json-strings": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.2.tgz",
+      "integrity": "sha512-w2DtsfXBBJddJacXMBhElGEYqCZQqN99Se1qeYn8DVLB33owlrlLftIbMzn5nz1OITfDVknXF433tBrLEAOEjA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.2.tgz",
+      "integrity": "sha512-1JAZtUrqYyGsS7IDmFeaem+/LJqujfLZ2weLR9ugB0ufUPjzf8cguyVT1g5im7f7RXxuLq1xUxEzvm68uYRtGg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.2.tgz",
+      "integrity": "sha512-ebR0zU9OvI2N4qiAC38KIAK75KItpIPTpAtd2r4OZmMFeKbKJpUFLYP2EuDut82+BmYi8sz42B+TfTptJ9iG5Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-numeric-separator": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.2.tgz",
+      "integrity": "sha512-DcTQY9syxu9BpU3Uo94fjCB3LN9/hgPS8oUL7KrSW3bA2ePrKZZPJcc5y0hoJAM9dft3pGfErtEUvxXQcfLxUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.2.tgz",
+      "integrity": "sha512-hBIQFxwZi8GIp934+nj5uV31mqclC1aYDhctDu5khTi9PCCUOczyy0b34W0oE9U/eJXiqQaKyVsmjeagOaSlbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.14.0",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.2.tgz",
+      "integrity": "sha512-XtkJsmJtBaUbOxZsNk0Fvrv8eiqgneug0A6aqLFZ4TSkar2L5dSXWcnUKHgmjJt49pyB/6ZHvkr3dPgl9MOWRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-optional-chaining": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.2.tgz",
+      "integrity": "sha512-qQByMRPwMZJainfig10BoaDldx/+VDtNcrA7qdNaEOAj6VXud+gfrkA8j4CRAU5HjnWREXqIpSpH30qZX1xivA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz",
+      "integrity": "sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.0.tgz",
+      "integrity": "sha512-59ANdmEwwRUkLjB7CRtwJxxwtjESw+X2IePItA+RGQh+oy5RmpCh/EvVVvh5XQc3yxsm5gtv0+i9oBZhaDNVTg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "@babel/helper-create-class-features-plugin": "^7.14.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz",
+      "integrity": "sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.12.13.tgz",
+      "integrity": "sha512-ZmKQ0ZXR0nYpHZIIuj9zE7oIqCx2hw9TKi+lIo73NNrMPAZGHfS92/VRV0ZmPj6H2ffBgyFHXvJ5NYsNeEaP2A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.0.tgz",
+      "integrity": "sha512-bda3xF8wGl5/5btF794utNOL0Jw+9jE5C1sLZcoK7c4uonE/y3iQiyG+KbkF3WBV/paX58VCpjhxLPkdj5Fe4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
+      "integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
+      "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz",
+      "integrity": "sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz",
+      "integrity": "sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-remap-async-to-generator": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.13.tgz",
+      "integrity": "sha512-zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.2.tgz",
+      "integrity": "sha512-neZZcP19NugZZqNwMTH+KoBjx5WyvESPSIOQb4JHpfd+zPfqcH65RMu5xJju5+6q/Y2VzYrleQTr+b6METyyxg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.2.tgz",
+      "integrity": "sha512-7oafAVcucHquA/VZCsXv/gmuiHeYd64UJyyTYU+MPfNu0KeNlxw06IeENBO8bJjXVbolu+j1MM5aKQtH1OMCNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "@babel/helper-function-name": "^7.14.2",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "globals": "^11.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz",
+      "integrity": "sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.17.tgz",
+      "integrity": "sha512-UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.13.tgz",
+      "integrity": "sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.13.tgz",
+      "integrity": "sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.13.tgz",
+      "integrity": "sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz",
+      "integrity": "sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.13.tgz",
+      "integrity": "sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.13.tgz",
+      "integrity": "sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.13.tgz",
+      "integrity": "sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.2.tgz",
+      "integrity": "sha512-hPC6XBswt8P3G2D1tSV2HzdKvkqOpmbyoy+g73JG0qlF/qx2y3KaMmXb1fLrpmWGLZYA0ojCvaHdzFWjlmV+Pw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.14.2",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.0.tgz",
+      "integrity": "sha512-EX4QePlsTaRZQmw9BsoPeyh5OCtRGIhwfLquhxGp5e32w+dyL8htOcDwamlitmNFK6xBZYlygjdye9dbd9rUlQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.14.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-simple-access": "^7.13.12",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
+      "integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-hoist-variables": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.0.tgz",
+      "integrity": "sha512-nPZdnWtXXeY7I87UZr9VlsWme3Y0cfFFE41Wbxz4bbaexAjNMInXPFUpRRUJ8NoMm0Cw+zxbqjdPmLhcjfazMw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.14.0",
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.13.tgz",
+      "integrity": "sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.13.tgz",
+      "integrity": "sha512-/KY2hbLxrG5GTQ9zzZSc3xWiOy379pIETEhbtzwZcw9rvuaVV4Fqy7BYGYOWZnaoXIQYbbJ0ziXLa/sKcGCYEQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz",
+      "integrity": "sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.2.tgz",
+      "integrity": "sha512-NxoVmA3APNCC1JdMXkdYXuQS+EMdqy0vIwyDHeKHiJKRxmp1qGSdb0JLEIoPRhkx6H/8Qi3RJ3uqOCYw8giy9A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.13.tgz",
+      "integrity": "sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.13.15.tgz",
+      "integrity": "sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-transform": "^0.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.13.tgz",
+      "integrity": "sha512-xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",
+      "integrity": "sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz",
+      "integrity": "sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.13.tgz",
+      "integrity": "sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz",
+      "integrity": "sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.13.tgz",
+      "integrity": "sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.3.tgz",
+      "integrity": "sha512-G5Bb5pY6tJRTC4ag1visSgiDoGgJ1u1fMUgmc2ijLkcIdzP83Q1qyZX4ggFQ/SkR+PNOatkaYC+nKcTlpsX4ag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.14.3",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-typescript": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz",
+      "integrity": "sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.13.tgz",
+      "integrity": "sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.2.tgz",
+      "integrity": "sha512-7dD7lVT8GMrE73v4lvDEb85cgcQhdES91BSD7jS/xjC6QY8PnRhux35ac+GCpbiRhp8crexBvZZqnaL6VrY8TQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.14.0",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
+        "@babel/plugin-proposal-async-generator-functions": "^7.14.2",
+        "@babel/plugin-proposal-class-properties": "^7.13.0",
+        "@babel/plugin-proposal-class-static-block": "^7.13.11",
+        "@babel/plugin-proposal-dynamic-import": "^7.14.2",
+        "@babel/plugin-proposal-export-namespace-from": "^7.14.2",
+        "@babel/plugin-proposal-json-strings": "^7.14.2",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.14.2",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
+        "@babel/plugin-proposal-numeric-separator": "^7.14.2",
+        "@babel/plugin-proposal-object-rest-spread": "^7.14.2",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.14.2",
+        "@babel/plugin-proposal-optional-chaining": "^7.14.2",
+        "@babel/plugin-proposal-private-methods": "^7.13.0",
+        "@babel/plugin-proposal-private-property-in-object": "^7.14.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.12.13",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.0",
+        "@babel/plugin-syntax-top-level-await": "^7.12.13",
+        "@babel/plugin-transform-arrow-functions": "^7.13.0",
+        "@babel/plugin-transform-async-to-generator": "^7.13.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.12.13",
+        "@babel/plugin-transform-block-scoping": "^7.14.2",
+        "@babel/plugin-transform-classes": "^7.14.2",
+        "@babel/plugin-transform-computed-properties": "^7.13.0",
+        "@babel/plugin-transform-destructuring": "^7.13.17",
+        "@babel/plugin-transform-dotall-regex": "^7.12.13",
+        "@babel/plugin-transform-duplicate-keys": "^7.12.13",
+        "@babel/plugin-transform-exponentiation-operator": "^7.12.13",
+        "@babel/plugin-transform-for-of": "^7.13.0",
+        "@babel/plugin-transform-function-name": "^7.12.13",
+        "@babel/plugin-transform-literals": "^7.12.13",
+        "@babel/plugin-transform-member-expression-literals": "^7.12.13",
+        "@babel/plugin-transform-modules-amd": "^7.14.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.14.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.13.8",
+        "@babel/plugin-transform-modules-umd": "^7.14.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
+        "@babel/plugin-transform-new-target": "^7.12.13",
+        "@babel/plugin-transform-object-super": "^7.12.13",
+        "@babel/plugin-transform-parameters": "^7.14.2",
+        "@babel/plugin-transform-property-literals": "^7.12.13",
+        "@babel/plugin-transform-regenerator": "^7.13.15",
+        "@babel/plugin-transform-reserved-words": "^7.12.13",
+        "@babel/plugin-transform-shorthand-properties": "^7.12.13",
+        "@babel/plugin-transform-spread": "^7.13.0",
+        "@babel/plugin-transform-sticky-regex": "^7.12.13",
+        "@babel/plugin-transform-template-literals": "^7.13.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.12.13",
+        "@babel/plugin-transform-unicode-escapes": "^7.12.13",
+        "@babel/plugin-transform-unicode-regex": "^7.12.13",
+        "@babel/preset-modules": "^0.1.4",
+        "@babel/types": "^7.14.2",
+        "babel-plugin-polyfill-corejs2": "^0.2.0",
+        "babel-plugin-polyfill-corejs3": "^0.2.0",
+        "babel-plugin-polyfill-regenerator": "^0.2.0",
+        "core-js-compat": "^3.9.0",
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+      "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.13.0.tgz",
+      "integrity": "sha512-LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-transform-typescript": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+      "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.14.2",
+        "@babel/helper-function-name": "^7.14.2",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.14.2",
+        "@babel/types": "^7.14.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
+      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^7.1.2",
+        "tslib": "~2.2.0",
+        "value-or-promise": "1.0.6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/aggregate-error": "0.0.6",
+        "camel-case": "4.1.2",
+        "tslib": "~2.2.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "dev": true
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.1.tgz",
+      "integrity": "sha512-50E6nN2F5cAXn1lDljn0gE9F0WFXHYz/u0EeR7sOt4nbRPNli34ckbl6CUDaDABJbHt62DYnyQAIB3KgdzwKDw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.1.tgz",
+      "integrity": "sha512-PiCbKSMf6t8PEfY3MAd0Ldn3aJAt5T+UcaFkAfMZ1VZgas35+fXk5uHIjAQHQLNIHZWX19TLv0wWNT03yvrw6w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^27.0.1",
+        "@jest/reporters": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/transform": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.8.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-changed-files": "^27.0.1",
+        "jest-config": "^27.0.1",
+        "jest-haste-map": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-regex-util": "^27.0.1",
+        "jest-resolve": "^27.0.1",
+        "jest-resolve-dependencies": "^27.0.1",
+        "jest-runner": "^27.0.1",
+        "jest-runtime": "^27.0.1",
+        "jest-snapshot": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-validate": "^27.0.1",
+        "jest-watcher": "^27.0.1",
+        "micromatch": "^4.0.4",
+        "p-each-series": "^2.1.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.1.tgz",
+      "integrity": "sha512-nG+r3uSs2pOTsdhgt6lUm4ZGJLRcTc6HZIkrFsVpPcdSqEpJehEny9r9y2Bmhkn8fKXWdGCYJKF3i4nKO0HSmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "jest-mock": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/environment/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.1.tgz",
+      "integrity": "sha512-3CyLJQnHzKI4TCJSCo+I9TzIHjSK4RrNEk93jFM6Q9+9WlSJ3mpMq/p2YuKMe0SiHKbmZOd5G/Ll5ofF9Xkw9g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "@sinonjs/fake-timers": "^7.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^27.0.1",
+        "jest-mock": "^27.0.1",
+        "jest-util": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/fake-timers/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.1.tgz",
+      "integrity": "sha512-80ZCzgopysKdpp5EOglgjApKxiNDR96PG4PwngB4fTwZ4qqqSKo0EwGwQIhl16szQ1M2xCVYmr9J6KelvnABNQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "expect": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/globals/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.1.tgz",
+      "integrity": "sha512-lZbJWuS1h/ytKERfu1D6tEQ4PuQ7+15S4+HrSzHR0i7AGVT1WRo49h4fZqxASOp7AQCupUVtPJNZDkaG9ZXy0g==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/transform": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.2.4",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "jest-haste-map": "^27.0.1",
+        "jest-resolve": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-worker": "^27.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/reporters/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.1.tgz",
+      "integrity": "sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.4",
+        "source-map": "^0.6.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/source-map/node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/source-map/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.1.tgz",
+      "integrity": "sha512-5aa+ibX2dsGSDLKaQMZb453MqjJU/CRVumebXfaJmuzuGE4qf87yQ2QZ6PEpEtBwVUEgrJCzi3jLCRaUbksSuw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/test-result/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/test-result/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.1.tgz",
+      "integrity": "sha512-yK2c2iruJ35WgH4KH8whS72uH+FASJUrzwxzNKTzLAEWmNpWKNEPOsSEKsHynvz78bLHafrTg4adN7RrYNbEOA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^27.0.1",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.0.1",
+        "jest-runner": "^27.0.1",
+        "jest-runtime": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.1.tgz",
+      "integrity": "sha512-LC95VpT6wMnQ96dRJDlUiAnW/90zyh4+jS30szI/5AsfS0qwSlr/O4TPcGoD2WVaVMfo6KvR+brvOtGyMHaNhA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^27.0.1",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.0.1",
+        "jest-regex-util": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/transform/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.4",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.4",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
+      "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.4.0.tgz",
+      "integrity": "sha512-V2qNML1knHjrjTJcIIvhYZSTkvtSAoQpNEX8y0ykTJI8vOQPqIh0y6Jf9EU6c/y+v0c9+LeC1acwLQh1xo96MA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.11.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.0.tgz",
+      "integrity": "sha512-+4NAJ9WzPN5gW6W1H1tblw/DesTD6PaWuU5+/x3Pa7nyK6qjR6cn4jwkJtzxVPTgtzryOFLX+5vs7MROFswp5Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.16.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.4.tgz",
+      "integrity": "sha512-n3Q5ikar6dFvGmSrzRwIrPvSAkwibQr5Ti0h722T/YuylsPYahRTmVEU1Vg+XIg8MHgHBTKmwBzz0IwpbseOtQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.3.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.17.0.tgz",
+      "integrity": "sha512-AHJ9H9pxL4JY3c/RyeK/yhh2qVWSCUcLX0l/5H9TtLUog7edcq+WMve+yPV+ciIyxWddPLI6xbOofXAf1Oepvg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^7.4.0"
+      }
+    },
+    "node_modules/@pika/babel-plugin-esm-import-rewrite": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@pika/babel-plugin-esm-import-rewrite/-/babel-plugin-esm-import-rewrite-0.6.1.tgz",
+      "integrity": "sha512-B6CMCfc8EZT/0WUqPZJWf7LCXbqq4R41F5Xbifcy0HaMDxScoEW1zFPrYQLUs9+8B365JnKq3n+U6kMkFYT45w==",
+      "dev": true
+    },
+    "node_modules/@pika/cli": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@pika/cli/-/cli-0.2.0.tgz",
+      "integrity": "sha512-DUWKfjpwXPGQlnYok2lqOLYuirTteEkXnLOWVYXAuS76BJv1dgCZkWG/tnLMb1DB7Xd4vtyp96/ajmfYceD2gQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "detect-indent": "^6.0.0",
+        "execa": "^2.0.3",
+        "resolve-from": "^5.0.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "bin": {
+        "pika": "dist-node/index.bin.js"
+      }
+    },
+    "node_modules/@pika/pack": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pika/pack/-/pack-0.5.0.tgz",
+      "integrity": "sha512-ernb1SHzvk1Mfi8pBVRAaCKtavz80IiIXG5kOuHsM9+ICxspypR6f7kdFWvglJjVhhdBrYSnecFK7W28fZCXjQ==",
+      "dev": true,
+      "dependencies": {
+        "@pika/cli": "latest",
+        "@pika/types": "^0.6.0",
+        "chalk": "^2.1.0",
+        "commander": "^2.9.0",
+        "file-uri-to-path": "^1.0.0",
+        "glob": "^7.1.1",
+        "import-from": "^3.0.0",
+        "invariant": "^2.2.0",
+        "is-builtin-module": "^3.0.0",
+        "is-ci": "^2.0.0",
+        "loud-rejection": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "np": "^5.0.2",
+        "rimraf": "^2.5.0",
+        "strip-ansi": "^5.2.0",
+        "strip-bom": "^4.0.0",
+        "validate-npm-package-license": "^3.0.4",
+        "yargs-parser": "^13.1.1"
+      },
+      "bin": {
+        "pika-pack": "dist-node/index.bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@pika/plugin-build-node": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pika/plugin-build-node/-/plugin-build-node-0.9.2.tgz",
+      "integrity": "sha512-NJhnx5UdOKRz4+3eSienp3vlwUTFYDtz2xAKlswb1td0q5n4gkxZhXoImNzF9PfAaMOXIb+7ngaBNSDiHguTkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-import-meta": "^7.2.0",
+        "@babel/preset-env": "^7.2.3",
+        "@pika/types": "^0.9.2",
+        "babel-plugin-dynamic-import-node-babel-7": "^2.0.7",
+        "builtin-modules": "^3.0.0",
+        "rollup": "^1.1.0",
+        "rollup-plugin-babel": "^4.3.0"
+      }
+    },
+    "node_modules/@pika/plugin-build-node/node_modules/@pika/types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pika/types/-/types-0.9.2.tgz",
+      "integrity": "sha512-AzZTkHtM0A67+xMVhmSeJDteSMS+RfXGuM+/oVbo1PGD19ic7fuimv5b0TW8dKoZuxpVxiwVAai+sFRSNmfI3g==",
+      "dev": true
+    },
+    "node_modules/@pika/plugin-build-web": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pika/plugin-build-web/-/plugin-build-web-0.9.2.tgz",
+      "integrity": "sha512-HjN/3P5c5jVEaPo9ZSs+jn9osrNs3JW3ZgP11NSfS0QQEMIw+Ks+qXi5Aymp8WKLpoldtZw/z69+SrfqlNeZyg==",
+      "dev": true,
+      "dependencies": {
+        "@pika/types": "^0.9.2",
+        "@types/node": "^10.12.18",
+        "rollup": "^1.1.0"
+      }
+    },
+    "node_modules/@pika/plugin-build-web/node_modules/@pika/types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pika/types/-/types-0.9.2.tgz",
+      "integrity": "sha512-AzZTkHtM0A67+xMVhmSeJDteSMS+RfXGuM+/oVbo1PGD19ic7fuimv5b0TW8dKoZuxpVxiwVAai+sFRSNmfI3g==",
+      "dev": true
+    },
+    "node_modules/@pika/plugin-build-web/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
+    },
+    "node_modules/@pika/plugin-ts-standard-pkg": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pika/plugin-ts-standard-pkg/-/plugin-ts-standard-pkg-0.9.2.tgz",
+      "integrity": "sha512-LwObacitvuILyXzdmbB1gyGtPjERxSF83omBHfoagsSUqgIf4FZDo9Z3v5VpI7Sq7mtIjQ7D3cjKv8r7JyyY5Q==",
+      "dev": true,
+      "dependencies": {
+        "@pika/types": "^0.9.2",
+        "execa": "^2.0.0",
+        "standard-pkg": "^0.5.0"
+      }
+    },
+    "node_modules/@pika/plugin-ts-standard-pkg/node_modules/@pika/types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@pika/types/-/types-0.9.2.tgz",
+      "integrity": "sha512-AzZTkHtM0A67+xMVhmSeJDteSMS+RfXGuM+/oVbo1PGD19ic7fuimv5b0TW8dKoZuxpVxiwVAai+sFRSNmfI3g==",
+      "dev": true
+    },
+    "node_modules/@pika/types": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@pika/types/-/types-0.6.1.tgz",
+      "integrity": "sha512-1ZsOHGc0qJDofO+/98PfchHJqJjtfZL3liVGi4QZ28GtLmTVuZ4SUJFa5NgbsYawnrr//pdNOfx9JiaLFKpzrA==",
+      "dev": true
+    },
+    "node_modules/@samverschueren/stream-to-observable": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+      "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
+      "dev": true,
+      "dependencies": {
+        "any-observable": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        },
+        "zen-observable": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@samverschueren/stream-to-observable/node_modules/any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
+      "integrity": "sha512-5bJma/oB7B4MtwUkZC2Bf7O1MHfi4gWe4mA+MIQ3lsEV0b422Bvl1z5HRpplDnMLHH3EXMoRdEng6Ds5wUqA3A==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.7",
+        "debug": "^4.0.0",
+        "import-from": "^3.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/error": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+      "dev": true
+    },
+    "node_modules/@semantic-release/github": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.3.tgz",
+      "integrity": "sha512-lWjIVDLal+EQBzy697ayUNN8MoBpp+jYIyW2luOdqn5XBH4d9bQGfTnjuLyzARZBHejqh932HVjiH/j4+R7VHw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/rest": "^18.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^10.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "issue-parser": "^6.0.0",
+        "lodash": "^4.17.4",
+        "mime": "^2.4.3",
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/globby": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.3.tgz",
+      "integrity": "sha512-x52kQ/jR09WjuWdaTEHgQCvZYMOTx68WnS+TZ4fya5ZAJw4oRtJETtrvUw10FdfM28d/keInQdc66R1Gw5+OEQ==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^6.0.0",
+        "npm": "^7.0.0",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^4.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/execa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.1.tgz",
+      "integrity": "sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.2.tgz",
+      "integrity": "sha512-xGFSidhGqB27uwgWCU6y0gbf4r/no5flOAkJyFFc4+bPf8S+LfAVm7xhhlK5VPXLt2Iu1RBH8F+IgMK2ah5YpA==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^4.0.0",
+        "get-stream": "^5.0.0",
+        "import-from": "^3.0.0",
+        "into-stream": "^6.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=15.8.0 <18.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.1.tgz",
+      "integrity": "sha512-am34LJf0N2nON/PT9G7pauA+xjcwX9P6x31m4hBgfUeSXYRZBRv/R6EcdWs8iV4XJjPO++NTsrj7ua/cN2s6ZA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.1.14",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+      "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "dev": true
+    },
+    "node_modules/@types/fetch-mock": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.3.tgz",
+      "integrity": "sha512-NLMbBVQh3yx6dMd5CnVxp9ZBhQYuFzWIlRk0kQbgBfyL75u3wtZyUTuFsK9Wb9G3eIw77yja858j1fQAWqM9Og==",
+      "dev": true
+    },
+    "node_modules/@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+      "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+      "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
+      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.1.tgz",
+      "integrity": "sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+      "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
+      "dev": true
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "15.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "dev": true
+    },
+    "node_modules/abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.0.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "dev": true
+    },
+    "node_modules/any-observable": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.5.1.tgz",
+      "integrity": "sha512-8zv01bgDOp9PTmRTNCAHTw64TFP2rvlX4LvtNJLachaXY+AjmIvLT47fABNPCiIe89hKiSCo2n5zmPqI9CElPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        },
+        "zen-observable": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/argv-formatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
+      "dev": true
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "node_modules/babel-jest": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.1.tgz",
+      "integrity": "sha512-aWFD7OGQjk3Y8MdZKf1XePlQvHnjMVJQjIq9WKrlAjz9by703kJ45Jxhp26JwnovoW71YYz5etuqRl8wMcIv0w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^27.0.1",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/babel-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/babel-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "dependencies": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "node_modules/babel-plugin-dynamic-import-node-babel-7": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node-babel-7/-/babel-plugin-dynamic-import-node-babel-7-2.0.7.tgz",
+      "integrity": "sha512-8DO7mdeczoxi0z1ggb6wS/yWkwM2F9uMPKsVeohK1Ff389JENDfZd+aINwM5r2p66IZGR0rkMrYCr2EyEGrGAQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.42"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+      "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^4.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.1.tgz",
+      "integrity": "sha512-sqBF0owAcCDBVEDtxqfYr2F36eSHdx7lAVGyYuOBRnKdD6gzcy0I0XrAYCZgOA3CRrLhmR+Uae9nogPzmAtOfQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+      "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.2.tgz",
+      "integrity": "sha512-l1Cf8PKk12eEk5QP/NQ6TH8A1pee6wWDJ96WjxrMXFLHLOBFzYM4moG80HFgduVhTqAFez4alnZKEhP/bYHg0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "core-js-compat": "^3.9.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+      "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.1.tgz",
+      "integrity": "sha512-nIBIqCEpuiyhvjQs2mVNwTxQQa2xk70p9Dd/0obQGBf8FBzbnI8QhQKzLsWMN2i6q+5B0OcWDtrboBX5gmOLyA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^27.0.1",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==",
+      "dev": true
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
+    },
+    "node_modules/boxen": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.4.2",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^3.0.0",
+        "term-size": "^1.2.0",
+        "type-fest": "^0.3.0",
+        "widest-line": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/boxen/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "dependencies": {
+        "caller-callsite": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/camel-case/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001230",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "dev": true,
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
+      "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
+      "dev": true
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
+      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "dev": true
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/compare-func/node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/compare-func/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/configstore": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
+      "integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-changelog-writer": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/map-obj": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/meow": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/normalize-package-data": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
+      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
+      "dev": true,
+      "dependencies": {
+        "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0",
+        "trim-off-newlines": "^1.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/map-obj": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/meow": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/normalize-package-data": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.0.tgz",
+      "integrity": "sha512-iWDbiyha1M5vFwPFmQnvRv+tJzGbFAm6XimJUT0NgHYW3xZEs1SkCAcasWSVFxpI2Xb/V1DDJckq3v90+bQnog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.13.0.tgz",
+      "integrity": "sha512-jhbI2zpVskgfDC9mGRaDo1gagd0E0i/kYW0+WvibL/rafEHKAHO653hEXIxJHqRlRLITluXtRH3AGTL5qJmifQ==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "semver": "7.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-compat/node_modules/semver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "dependencies": {
+        "array-find-index": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+      "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "node_modules/dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+      "dev": true
+    },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/del": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
+    },
+    "node_modules/detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.741",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.741.tgz",
+      "integrity": "sha512-4i3T0cwnHo1O4Mnp9JniEco8bZiXoqbm3PhW5hv7uu8YLg35iajYrRnNyKFaN8/8SSTskU2hYqVTeYVPceSpUA==",
+      "dev": true
+    },
+    "node_modules/elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emittery": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
+      "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-ci": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
+      "integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^4.0.0",
+        "java-properties": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/env-ci/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/env-ci/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^3.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.1.tgz",
+      "integrity": "sha512-hjKwLeAvKUiq0Plha1dmzOH1FGEwJC9njbT993cq4PK9r58/+3NM+WDqFVGcPuRH7XTjmbIeHQBzp2faDrPhjQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-styles": "^5.0.0",
+        "jest-get-type": "^27.0.1",
+        "jest-matcher-utils": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-regex-util": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/expect/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/expect/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expect/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "dev": true,
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "dependencies": {
+        "semver-regex": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/from2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/from2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-log-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+      "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+      "dev": true,
+      "dependencies": {
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
+      }
+    },
+    "node_modules/git-log-parser/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/git-log-parser/node_modules/split2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+      "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+      "dev": true,
+      "dependencies": {
+        "through2": "~2.0.0"
+      }
+    },
+    "node_modules/git-log-parser/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/git-log-parser/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/github-openapi-graphql-query": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/github-openapi-graphql-query/-/github-openapi-graphql-query-1.0.5.tgz",
+      "integrity": "sha512-EFLhj99a+Vt8BQ7uKGbzzAgSXXPIlUlOfj8E1bnHU+fIAdXCI0Z6/TdoDEwu2Ld9wh+xnvTfJ6cZ/Dn2BCvU9w==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "^7.1.5",
+        "got": "^11.8.2",
+        "graphql": "^15.5.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/got": {
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/keyv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      }
+    },
+    "node_modules/github-openapi-graphql-query/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
+    "node_modules/global-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "1.3.7"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/globby/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/got/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hook-std": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz",
+      "integrity": "sha512-mzNrusCk5L6kSzlN0Ioddn8yzrhYNLli+Sn2ZxMuLechMYAzakiFCIULxsxlQb5YKzthLGfrFACcWoAvM7p04Q==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "inquirer": "^6.2.1",
+        "rxjs": "^6.3.3"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer-autosubmit-prompt/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/into-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "dev": true,
+      "dependencies": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/into-stream/node_modules/p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "dependencies": {
+        "symbol-observable": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+      "dev": true,
+      "dependencies": {
+        "is-path-inside": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+      "dev": true,
+      "dependencies": {
+        "path-is-inside": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-scoped": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-2.1.0.tgz",
+      "integrity": "sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==",
+      "dev": true,
+      "dependencies": {
+        "scoped-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "dev": true,
+      "dependencies": {
+        "text-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/is-url-superb": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
+      "dev": true,
+      "dependencies": {
+        "url-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/issue-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
+      "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/issue-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/issue-regex/-/issue-regex-2.0.0.tgz",
+      "integrity": "sha512-flaQ/45dMqCYSMzBQI/h3bcto6T70uN7kjNnI8n3gQU6no5p+QcnMWBNXkraED0YvbUymxKaqdvgPa09RZQM5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/java-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.1.tgz",
+      "integrity": "sha512-lFEoUdXjbGAIxk/gZhcv98xOaH1hjqG5R/PQHs5GBfIK5iL3tnXCjHQf4HQLVZZ2rcXML3oeVg9+XrRZbooBdQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^27.0.1",
+        "import-local": "^3.0.2",
+        "jest-cli": "^27.0.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.1.tgz",
+      "integrity": "sha512-Y/4AnqYNcUX/vVgfkmvSA3t7rcg+t8m3CsSGlU+ra8kjlVW5ZqXcBZY/NUew2Mo8M+dn0ApKl+FmGGT1JV5dVA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "execa": "^5.0.0",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-changed-files/node_modules/execa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.1.tgz",
+      "integrity": "sha512-Tz3ytmrsgxWlTwSyPYb8StF9J2IMjLlbBMKAjhL2UU9/0ZpYb2JiEGjXaAhnGauQRbbpyFbSH3yj5HIbdurmwQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "expect": "^27.0.1",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.0.1",
+        "jest-matcher-utils": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-runner": "^27.0.1",
+        "jest-runtime": "^27.0.1",
+        "jest-snapshot": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "pretty-format": "^27.0.1",
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-circus/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.1.tgz",
+      "integrity": "sha512-V8O6+CZjGF0OMq4kxVR29ztV/LQqlAAcJLw7a94RndfRXkha4U84n50yZCXiPWtAHHTmb3g1y52US6rGPxA+3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "babel-jest": "^27.0.1",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^3.0.0",
+        "jest-circus": "^27.0.1",
+        "jest-environment-jsdom": "^27.0.1",
+        "jest-environment-node": "^27.0.1",
+        "jest-get-type": "^27.0.1",
+        "jest-jasmine2": "^27.0.1",
+        "jest-regex-util": "^27.0.1",
+        "jest-resolve": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-validate": "^27.0.1",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "dev": true
+    },
+    "node_modules/jest-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/is-ci": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
+      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.1.1"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/jest-config/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.1.tgz",
+      "integrity": "sha512-TA4+21s3oebURc7VgFV4r7ltdIJ5rtBH1E3Tbovcg7AV+oLfD5DcJ2V2vJ5zFA9sL5CFd/d2D6IpsAeSheEdrA==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.1.tgz",
+      "integrity": "sha512-uJTK/aZ05HsdKkfXucAT5+/1DIURnTRv34OSxn1HWHrD+xu9eDX5Xgds09QSvg/mU01VS5upuHTDKG3W+r0rQA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-each/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-each/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.1.tgz",
+      "integrity": "sha512-lesU8T9zkjgLaLpUFmFDgchu6/2OCoXm52nN6UumR063Hb+1TJdI7ihgM86+G01Ay86Lyr+K/FAR6yIIOviH3Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^27.0.1",
+        "@jest/fake-timers": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "jest-mock": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jsdom": "^16.6.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.1.tgz",
+      "integrity": "sha512-/p94lo0hx+hbKUw1opnRFUPPsjncRBEUU+2Dh7BuxX8Nr4rRiTivLYgXzo79FhaeMYV0uiV5WAbHBq6xC11JJg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^27.0.1",
+        "@jest/fake-timers": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "jest-mock": "^27.0.1",
+        "jest-util": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-environment-node/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-node/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.1.tgz",
+      "integrity": "sha512-ioCuobr4z90H1Pz8+apz2vfz63387apzAoawm/9IIOndarDfRkjLURdLOe//AI5jUQmjVRg+WiL92339kqlCmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-regex-util": "^27.0.1",
+        "jest-serializer": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-worker": "^27.0.1",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-haste-map/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-jasmine2": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.1.tgz",
+      "integrity": "sha512-o8Ist0o970QDDm/R2o9UDbvNxq8A0++FTFQ0z9OnieJwS1nDH6H7WBDYAGPTdmnla7kbW41oLFPvhmjJE4mekg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^27.0.1",
+        "@jest/source-map": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^27.0.1",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.0.1",
+        "jest-matcher-utils": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-runtime": "^27.0.1",
+        "jest-snapshot": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "pretty-format": "^27.0.1",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-jasmine2/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-jasmine2/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.1.tgz",
+      "integrity": "sha512-SQ/lRhfmnV3UuiaKIjwNXCaW2yh1rTMAL4n4Cl4I4gU0X2LoIc6Ogxe4UKM/J6Ld2uzc4gDGVYc5lSdpf6WjYw==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^27.0.1",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-leak-detector/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.1.tgz",
+      "integrity": "sha512-NauNU+olKhPzLlsRnTOYFGk/MK5QFYl9ZzkrtfsY4eCq4SB3Bcl03UL44VdnlN5S/uFn4H2jwvRY1y6nSDTX3g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.0.1",
+        "jest-get-type": "^27.0.1",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-matcher-utils/node_modules/diff-sequences": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
+      "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/jest-diff": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.1.tgz",
+      "integrity": "sha512-DQ3OgfJgoGWVTYo4qnYW/Jg5mpYFS2QW9BLxA8bs12ZRN1K8QPZtWeYvUPohQFs3CHX3JLTndGg3jyxdL5THFQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.0.1",
+        "jest-get-type": "^27.0.1",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.1.tgz",
+      "integrity": "sha512-w8BfON2GwWORkos8BsxcwwQrLkV2s1ENxSRXK43+6yuquDE2hVxES/jrFqOArpP1ETVqqMmktU6iGkG8ncVzeA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^27.0.1",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^27.0.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-message-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.1.tgz",
+      "integrity": "sha512-fXCSZQDT5hUcAUy8OBnB018x7JFOMQnz4XfpSKEbfpWzL6o5qaLRhgf2Qg2NPuVKmC/fgOf33Edj8wjF4I24CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-mock/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-mock/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-mock/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-mock/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
+      "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.1.tgz",
+      "integrity": "sha512-Q7QQ0OZ7z6D5Dul0MrsexlKalU8ZwexBfHLSu1qYPgphvUm6WO1b/xUnipU3e+uW1riDzMcJeJVYbdQ37hBHeg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "chalk": "^4.0.0",
+        "escalade": "^3.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^27.0.1",
+        "resolve": "^1.20.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.1.tgz",
+      "integrity": "sha512-ly1x5mEf21f3IVWbUNwIz/ePLtv4QdhYuQIVSVDqxx7yzAwhhdu0DJo7UNiEYKQY7Im48wfbNdOUpo7euFUXBQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "jest-regex-util": "^27.0.1",
+        "jest-snapshot": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve-dependencies/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-resolve/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.1.tgz",
+      "integrity": "sha512-DUNizlD2D7J80G3VOrwfbtb7KYxiftMng82HNcKwTW0W3AwwNuBeq+1exoCnLO7Mxh7NP+k/1XQBlzLpjr/CnA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^27.0.1",
+        "@jest/environment": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/transform": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.8.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^27.0.1",
+        "jest-docblock": "^27.0.1",
+        "jest-haste-map": "^27.0.1",
+        "jest-leak-detector": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-resolve": "^27.0.1",
+        "jest-runtime": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-worker": "^27.0.1",
+        "source-map-support": "^0.5.6",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-runner/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.1.tgz",
+      "integrity": "sha512-ImcrbQtpCUp8X9Rm4ky3j1GG9cqIKZJvXGZyB5cHEapGPTmg7wvvNooLmKragEe61/p/bhw1qO68Y0/9BSsBBg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^27.0.1",
+        "@jest/environment": "^27.0.1",
+        "@jest/fake-timers": "^27.0.1",
+        "@jest/globals": "^27.0.1",
+        "@jest/source-map": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/transform": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-mock": "^27.0.1",
+        "jest-regex-util": "^27.0.1",
+        "jest-resolve": "^27.0.1",
+        "jest-snapshot": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-validate": "^27.0.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^16.0.3"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-runtime/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-serializer": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.1.tgz",
+      "integrity": "sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "graceful-fs": "^4.2.4"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.1.tgz",
+      "integrity": "sha512-HgKmSebDB3rswugREeh+nKrxJEVZE12K7lZ2MuwfFZT6YmiH0TlofsL2YmiLsCsG5KH5ZcLYYpF5bDrvtVx/Xg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.7.2",
+        "@babel/generator": "^7.7.2",
+        "@babel/parser": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.0.0",
+        "@jest/transform": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^27.0.1",
+        "graceful-fs": "^4.2.4",
+        "jest-diff": "^27.0.1",
+        "jest-get-type": "^27.0.1",
+        "jest-haste-map": "^27.0.1",
+        "jest-matcher-utils": "^27.0.1",
+        "jest-message-util": "^27.0.1",
+        "jest-resolve": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^27.0.1",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-snapshot/node_modules/diff-sequences": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
+      "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-diff": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.1.tgz",
+      "integrity": "sha512-DQ3OgfJgoGWVTYo4qnYW/Jg5mpYFS2QW9BLxA8bs12ZRN1K8QPZtWeYvUPohQFs3CHX3JLTndGg3jyxdL5THFQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.0.1",
+        "jest-get-type": "^27.0.1",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.1.tgz",
+      "integrity": "sha512-lEw3waSmEOO4ZkwkUlFSvg4es1+8+LIkSGxp/kF60K0+vMR3Dv3O2HMZhcln9NHqSQzpVbsDT6OeMzUPW7DfRg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^3.0.0",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "dev": true
+    },
+    "node_modules/jest-util/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/is-ci": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
+      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.1.1"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.1.tgz",
+      "integrity": "sha512-zvmPRcfTkqTZuHveIKAI2nbkUc3SDXjWVJULknPLGF5bdxOGSeGZg7f/Uw0MUVOkCOaspcHnsPCgZG0pqmg71g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^27.0.1",
+        "leven": "^3.1.0",
+        "pretty-format": "^27.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-validate/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate/node_modules/jest-get-type": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.1.tgz",
+      "integrity": "sha512-qE+0J6c/gd+R6XTcQgPJMc5hMJNsxzSF5p8iZSbMZ7GQzYGlSLNkh2P80Wa2dbF4gEVUsJEgcrBY+1L2/j265w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.0.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.1.tgz",
+      "integrity": "sha512-Chp9c02BN0IgEbtGreyAhGqIsOrn9a0XnzbuXOxdW1+cW0Tjh12hMzHDIdLFHpYP/TqaMTmPHaJ5KWvpCCrNFw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "jest-util": "^27.0.1",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-watcher/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.1.tgz",
+      "integrity": "sha512-NhHqClI3owOjmS8dBhQMKHZ2rrT0sBTpqGitp9nMX5AAjVXd+15o4v96uBEMhoywaLKN+5opcKBlXwAoADZolA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest/node_modules/@jest/types": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.1.tgz",
+      "integrity": "sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest/node_modules/@types/yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest/node_modules/jest-cli": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.1.tgz",
+      "integrity": "sha512-plDsQQwpkKK1SZ5L5xqMa7v/sTwB5LTIeSJqb+cV+4EMlThdUQfg8jwMfHX8jHuUc9TPGLcdoZeBuZcGGn3Rlg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^27.0.1",
+        "@jest/test-result": "^27.0.1",
+        "@jest/types": "^27.0.1",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "import-local": "^3.0.2",
+        "jest-config": "^27.0.1",
+        "jest-util": "^27.0.1",
+        "jest-validate": "^27.0.1",
+        "prompts": "^2.0.1",
+        "yargs": "^16.0.3"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
+      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.5",
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/acorn": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
+      "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+      "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ]
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "dependencies": {
+        "package-json": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "dependencies": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/listr-input": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/listr-input/-/listr-input-0.2.1.tgz",
+      "integrity": "sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==",
+      "dev": true,
+      "dependencies": {
+        "inquirer": "^7.0.0",
+        "inquirer-autosubmit-prompt": "^0.2.0",
+        "rxjs": "^6.5.3",
+        "through": "^2.3.8"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "listr": "^0.14.2"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+      "dev": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "node_modules/lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
+    "node_modules/lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loud-rejection": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
+      "integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
+      "dev": true,
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
+    },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/make-dir/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "dependencies": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/marked": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.6.tgz",
+      "integrity": "sha512-S2mYj0FzTQa0dLddssqwRVW4EOJOVJ355Xm2Vcbm+LU7GQRGWvwbO5K87OaPSOux2AwTSgtPPaXmc8sDPrhn2A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 8.16.2"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
+      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.1",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.0",
+        "cli-table": "^0.3.1",
+        "node-emoji": "^1.10.0",
+        "supports-hyperlinks": "^2.1.0"
+      },
+      "peerDependencies": {
+        "marked": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/marked-terminal/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "dependencies": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/meow": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/meow/node_modules/camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/meow/node_modules/loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/meow/node_modules/yargs-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^4.1.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.47.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/nerf-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
+    },
+    "node_modules/node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "dev": true,
+      "dependencies": {
+        "lodash.toarray": "^4.4.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node_modules/node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+      "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/np": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/np/-/np-5.2.1.tgz",
+      "integrity": "sha512-KGSFQGHob6FMOWCrBgaqJNu/G9ghA5Rfbt3NXOz2alKzEwC1Xvk/vIem6dbKm3HjyII1WpfI+Xymx51i2gJMhA==",
+      "dev": true,
+      "dependencies": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "any-observable": "^0.5.0",
+        "async-exit-hook": "^2.0.1",
+        "chalk": "^3.0.0",
+        "cosmiconfig": "^5.2.1",
+        "del": "^4.1.0",
+        "escape-string-regexp": "^2.0.0",
+        "execa": "^3.4.0",
+        "github-url-from-git": "^1.5.0",
+        "has-yarn": "^2.1.0",
+        "hosted-git-info": "^3.0.0",
+        "inquirer": "^7.0.0",
+        "is-installed-globally": "^0.3.1",
+        "is-scoped": "^2.1.0",
+        "issue-regex": "^2.0.0",
+        "listr": "^0.14.3",
+        "listr-input": "^0.2.0",
+        "log-symbols": "^3.0.0",
+        "meow": "^5.0.0",
+        "npm-name": "^5.4.0",
+        "onetime": "^5.1.0",
+        "open": "^7.0.0",
+        "ow": "^0.15.0",
+        "p-memoize": "^3.1.0",
+        "p-timeout": "^3.1.0",
+        "pkg-dir": "^4.1.0",
+        "read-pkg-up": "^7.0.0",
+        "rxjs": "^6.3.3",
+        "semver": "^6.1.2",
+        "split": "^1.0.0",
+        "symbol-observable": "^1.2.0",
+        "terminal-link": "^2.0.0",
+        "update-notifier": "^3.0.0"
+      },
+      "bin": {
+        "np": "source/cli.js"
+      },
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=8",
+        "npm": ">=6.8.0",
+        "yarn": ">=1.7.0"
+      }
+    },
+    "node_modules/np/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/np/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/np/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/np/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/np/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/np/node_modules/execa": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "node_modules/np/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/np/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/np/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.15.0.tgz",
+      "integrity": "sha512-GIXNqy3obii54oPF0gbcBNq4aYuB/Ovuu/uYp1eS4nij2PEDMnoOh6RoSv2MDvAaB4a+JbpX/tjDxLO7JAADgQ==",
+      "bundleDependencies": [
+        "@npmcli/arborist",
+        "@npmcli/ci-detect",
+        "@npmcli/config",
+        "@npmcli/run-script",
+        "abbrev",
+        "ansicolors",
+        "ansistyles",
+        "archy",
+        "byte-size",
+        "cacache",
+        "chalk",
+        "chownr",
+        "cli-columns",
+        "cli-table3",
+        "columnify",
+        "glob",
+        "graceful-fs",
+        "hosted-git-info",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-even-better-errors",
+        "leven",
+        "libnpmaccess",
+        "libnpmdiff",
+        "libnpmexec",
+        "libnpmfund",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmpack",
+        "libnpmpublish",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpmversion",
+        "make-fetch-happen",
+        "minipass",
+        "minipass-pipeline",
+        "mkdirp",
+        "mkdirp-infer-owner",
+        "ms",
+        "node-gyp",
+        "nopt",
+        "npm-audit-report",
+        "npm-package-arg",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "npmlog",
+        "opener",
+        "pacote",
+        "parse-conflict-json",
+        "qrcode-terminal",
+        "read",
+        "read-package-json",
+        "read-package-json-fast",
+        "readdir-scoped-modules",
+        "rimraf",
+        "semver",
+        "ssri",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "treeverse",
+        "validate-npm-package-name",
+        "which",
+        "write-file-atomic"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@npmcli/arborist": "^2.6.0",
+        "@npmcli/ci-detect": "^1.2.0",
+        "@npmcli/config": "^2.2.0",
+        "@npmcli/run-script": "^1.8.5",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "archy": "~1.0.0",
+        "byte-size": "^7.0.1",
+        "cacache": "^15.2.0",
+        "chalk": "^4.1.0",
+        "chownr": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.6.0",
+        "columnify": "~1.5.4",
+        "glob": "^7.1.7",
+        "graceful-fs": "^4.2.6",
+        "hosted-git-info": "^4.0.2",
+        "ini": "^2.0.0",
+        "init-package-json": "^2.0.3",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "leven": "^3.1.0",
+        "libnpmaccess": "^4.0.2",
+        "libnpmdiff": "^2.0.4",
+        "libnpmexec": "^1.1.1",
+        "libnpmfund": "^1.1.0",
+        "libnpmhook": "^6.0.2",
+        "libnpmorg": "^2.0.2",
+        "libnpmpack": "^2.0.1",
+        "libnpmpublish": "^4.0.1",
+        "libnpmsearch": "^3.1.1",
+        "libnpmteam": "^2.0.3",
+        "libnpmversion": "^1.2.0",
+        "make-fetch-happen": "^8.0.14",
+        "minipass": "^3.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^7.1.2",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^2.1.5",
+        "npm-package-arg": "^8.1.2",
+        "npm-pick-manifest": "^6.1.1",
+        "npm-profile": "^5.0.3",
+        "npm-registry-fetch": "^10.1.2",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "~4.1.2",
+        "opener": "^1.5.2",
+        "pacote": "^11.3.3",
+        "parse-conflict-json": "^1.1.1",
+        "qrcode-terminal": "^0.12.0",
+        "read": "~1.0.7",
+        "read-package-json": "^3.0.1",
+        "read-package-json-fast": "^2.0.2",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.0",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "treeverse": "^1.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^3.0.3"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-name": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/npm-name/-/npm-name-5.5.0.tgz",
+      "integrity": "sha512-l7/uyVfEi2e3ho+ovaJZC0xlbwzXNUz3RxkxpfcnLuoGKAuYoo9YoJ/uy18PsTD8IziugGHks4t/mGmBJEZ4Qg==",
+      "dev": true,
+      "dependencies": {
+        "got": "^9.6.0",
+        "is-scoped": "^2.1.0",
+        "is-url-superb": "^3.0.0",
+        "lodash.zip": "^4.2.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.1.0",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "2.6.0",
+      "integrity": "sha512-6njRVuPMgGRvQUmsXwGdp1ItZtJuSdt5ouoQe4AeFTTZoMufKWLeXFDOlWj7qbMAzqw+guNEAZwBiwm04J7T2g==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/map-workspaces": "^1.0.2",
+        "@npmcli/metavuln-calculator": "^1.1.0",
+        "@npmcli/move-file": "^1.1.0",
+        "@npmcli/name-from-folder": "^1.0.1",
+        "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/run-script": "^1.8.2",
+        "bin-links": "^2.2.1",
+        "cacache": "^15.0.3",
+        "common-ancestor-path": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "json-stringify-nice": "^1.1.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-install-checks": "^4.0.0",
+        "npm-package-arg": "^8.1.0",
+        "npm-pick-manifest": "^6.1.0",
+        "npm-registry-fetch": "^10.0.0",
+        "pacote": "^11.2.6",
+        "parse-conflict-json": "^1.1.1",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^1.0.1",
+        "read-package-json-fast": "^2.0.2",
+        "readdir-scoped-modules": "^1.1.0",
+        "semver": "^7.3.5",
+        "tar": "^6.1.0",
+        "treeverse": "^1.0.4",
+        "walk-up-path": "^1.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/ci-detect": {
+      "version": "1.3.0",
+      "integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/@npmcli/config": {
+      "version": "2.2.0",
+      "integrity": "sha512-y0V3F7RCWXy8kBOvKvKSRUNKRobLB6vL/UNchy/6+IUNIqu+UyrY3Z7jvj1ZA/AkYc/0WkCUtppCo+bPhMU8Aw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ini": "^2.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^5.0.0",
+        "semver": "^7.3.4",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
+      "version": "1.0.1",
+      "integrity": "sha512-kQ1aCTTU45mPXN+pdAaRxlxr3OunkyztjbbxDY/aIcPS5CnCUrx+1+NvA6pTcYR7wmLZe37+Mi5v3nfbwPxq3A==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ansi-styles": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/git": {
+      "version": "2.0.9",
+      "integrity": "sha512-hTMbMryvOqGLwnmMBKs5usbPsJtyEsMsgXwJbmNrsEuQQh1LAIMDU77IoOrwkCg+NgQWl+ySlarJASwM3SutCA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/promise-spawn": "^1.3.2",
+        "lru-cache": "^6.0.0",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^6.1.1",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "1.0.7",
+      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "installed-package-contents": "index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "1.0.3",
+      "integrity": "sha512-SdlRlOoQw4WKD4vtb/n5gUkobEABYBEOo8fRE4L8CtBkyWDSvIrReTfKvQ/Jc/LQqDaaZ5iv1iMSQzKCUr1n1A==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/name-from-folder": "^1.0.1",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4",
+        "read-package-json-fast": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "1.1.1",
+      "integrity": "sha512-9xe+ZZ1iGVaUovBVFI9h3qW+UuECUzhvZPxK9RaEA2mjU26o5D0JloGYWwLYvQELJNmBdQB6rrpuN8jni6LwzQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "cacache": "^15.0.5",
+        "pacote": "^11.1.11",
+        "semver": "^7.3.2"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "1.0.1",
+      "integrity": "sha512-qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "1.0.2",
+      "integrity": "sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "1.3.2",
+      "integrity": "sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "1.8.5",
+      "integrity": "sha512-NQspusBCpTjNwNRFMtz2C5MxoxyzlbuJ4YEhxAKrIonTiirKDtatsZictx9RgamQIx6+QuHMNmPl0wQdoESs9A==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/node-gyp": "^1.0.2",
+        "@npmcli/promise-spawn": "^1.3.2",
+        "infer-owner": "^1.0.4",
+        "node-gyp": "^7.1.0",
+        "read-package-json-fast": "^2.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/abbrev": {
+      "version": "1.1.1",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "6.0.2",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/agentkeepalive": {
+      "version": "4.1.4",
+      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/ajv": {
+      "version": "6.12.6",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/ansicolors": {
+      "version": "0.3.2",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/ansistyles": {
+      "version": "0.1.3",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/aproba": {
+      "version": "2.0.0",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "1.1.5",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/asn1": {
+      "version": "0.2.4",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/asynckit": {
+      "version": "0.4.0",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/aws4": {
+      "version": "1.11.0",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "2.2.1",
+      "integrity": "sha512-wFzVTqavpgCCYAh8SVBdnZdiQMxTkGR+T3b14CNpBXIBe2neJWaMGAZ55XWWHELJJ89dscuq0VCBqcVaIOgCMg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "cmd-shim": "^4.0.1",
+        "mkdirp": "^1.0.3",
+        "npm-normalize-package-bin": "^1.0.0",
+        "read-cmd-shim": "^2.0.0",
+        "rimraf": "^3.0.0",
+        "write-file-atomic": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/builtins": {
+      "version": "1.0.3",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/byte-size": {
+      "version": "7.0.1",
+      "integrity": "sha512-crQdqyCwhokxwV1UyDzLZanhkugAgft7vt0qbbdt60C6Zf3CAiGmtUCylbtYwrU6loOUw3euGrNtW1J651ot1A==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/cacache": {
+      "version": "15.2.0",
+      "integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/caseless": {
+      "version": "0.12.0",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "4.1.1",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/chownr": {
+      "version": "2.0.0",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/cidr-regex": {
+      "version": "3.1.1",
+      "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ip-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns": {
+      "version": "3.1.2",
+      "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3": {
+      "version": "0.6.0",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.2",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/cmd-shim": {
+      "version": "4.1.0",
+      "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "mkdirp-infer-owner": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-convert": {
+      "version": "2.0.1",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-name": {
+      "version": "1.1.4",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/colors": {
+      "version": "1.4.0",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "inBundle": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/npm/node_modules/columnify": {
+      "version": "1.5.4",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/dashdash": {
+      "version": "1.14.1",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "4.3.1",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/depd": {
+      "version": "1.1.2",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.3",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/diff": {
+      "version": "5.0.0",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/encoding": {
+      "version": "0.1.13",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "inBundle": true,
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/err-code": {
+      "version": "2.0.3",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/extend": {
+      "version": "3.0.2",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/extsprintf": {
+      "version": "1.3.0",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/form-data": {
+      "version": "2.3.3",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/gauge": {
+      "version": "2.7.4",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
+      "version": "1.2.0",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/getpass": {
+      "version": "0.1.7",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/glob": {
+      "version": "7.1.7",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/har-schema": {
+      "version": "2.0.0",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator": {
+      "version": "5.1.5",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/has-flag": {
+      "version": "4.0.0",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/http-signature": {
+      "version": "1.2.0",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.6.2",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "dev": true,
+      "inBundle": true,
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ignore-walk": {
+      "version": "3.0.4",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/npm/node_modules/indent-string": {
+      "version": "4.0.0",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/ini": {
+      "version": "2.0.0",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/init-package-json": {
+      "version": "2.0.3",
+      "integrity": "sha512-tk/gAgbMMxR6fn1MgMaM1HpU1ryAmBWWitnxG5OhuNXeX0cbpbgV5jA4AIpQJVNoyOfOevTtO6WX+rPs+EFqaQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "glob": "^7.1.1",
+        "npm-package-arg": "^8.1.2",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "^3.0.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/ip": {
+      "version": "1.1.5",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/ip-regex": {
+      "version": "4.3.0",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "4.0.2",
+      "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "cidr-regex": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/is-core-module": {
+      "version": "2.4.0",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-lambda": {
+      "version": "1.0.1",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/isarray": {
+      "version": "1.0.0",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/isstream": {
+      "version": "0.1.2",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "0.1.1",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/json-schema": {
+      "version": "0.2.3",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+      "dev": true,
+      "inBundle": true,
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/jsprim": {
+      "version": "1.4.1",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/just-diff": {
+      "version": "3.1.1",
+      "integrity": "sha512-sdMWKjRq8qWZEjDcVA6llnUT8RDEBIfOiGpYFPYa9u+2c39JCsejktSP7mj5eRid5EIvTzIpQ2kDOCw1Nq9BjQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/just-diff-apply": {
+      "version": "3.0.0",
+      "integrity": "sha512-K2MLc+ZC2DVxX4V61bIKPeMUUfj1YYZ3h0myhchDXOW1cKoPZMnjIoNCqv9bF2n5Oob1PFxuR2gVJxkxz4e58w==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/leven": {
+      "version": "3.1.0",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "4.0.2",
+      "integrity": "sha512-avXtJibZuGap0/qADDYqb9zdpgzVu/yG5+tl2sTRa7MCkDNv2ZlGwCYI0r6/+tmqXPj0iB9fKexHz426vB326w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "minipass": "^3.1.1",
+        "npm-package-arg": "^8.1.2",
+        "npm-registry-fetch": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "2.0.4",
+      "integrity": "sha512-q3zWePOJLHwsLEUjZw3Kyu/MJMYfl4tWCg78Vl6QGSfm4aXBUSVzMzjJ6jGiyarsT4d+1NH4B1gxfs62/+y9iQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/disparity-colors": "^1.0.1",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "npm-package-arg": "^8.1.1",
+        "pacote": "^11.3.0",
+        "tar": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "1.1.1",
+      "integrity": "sha512-uw6H2dzC6F6fdq7lAxfzXPimHCJ3/g6ycFKcv2Q2QXuNZ94EDmNPpMO6f4mwiC5F6Lyy/WK0IL7AZwRhmSvUdQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/arborist": "^2.3.0",
+        "@npmcli/ci-detect": "^1.3.0",
+        "@npmcli/run-script": "^1.8.4",
+        "chalk": "^4.1.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-package-arg": "^8.1.2",
+        "pacote": "^11.3.1",
+        "proc-log": "^1.0.0",
+        "read": "^1.0.7",
+        "read-package-json-fast": "^2.0.2",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmfund": {
+      "version": "1.1.0",
+      "integrity": "sha512-Kfmh3pLS5/RGKG5WXEig8mjahPVOxkik6lsbH4iX0si1xxNi6eeUh/+nF1MD+2cgalsQif3O5qyr6mNz2ryJrQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/arborist": "^2.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "6.0.2",
+      "integrity": "sha512-fTw+8i6iyz9v6azSvQEVYxQhAaE2X1eiVMAUqsiwECWeylyc5KUoghHyYg0Kz5jEy9IOTaWYJXc6gMf0rQFpow==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "2.0.2",
+      "integrity": "sha512-FY5Mzd2CblVqLWwhEIuefzdWwZOxYN1Vvk8KnXxrPhXHDijuQqaN9wgxZlsHwdGC02kPoDKkg67mH/ir/W/YLQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "2.0.1",
+      "integrity": "sha512-He4/jxOwlaQ7YG7sIC1+yNeXeUDQt8RLBvpI68R3RzPMZPa4/VpxhlDo8GtBOBDYoU8eq6v1wKL38sq58u4ibQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/run-script": "^1.8.3",
+        "npm-package-arg": "^8.1.0",
+        "pacote": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "4.0.1",
+      "integrity": "sha512-hZCrZ8v4G9YH3DxpIyBdob25ijD5v5LNzRbwsej4pPDopjdcLLj1Widl+BUeFa7D0ble1JYL4F3owjLJqiA8yA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "normalize-package-data": "^3.0.2",
+        "npm-package-arg": "^8.1.2",
+        "npm-registry-fetch": "^10.0.0",
+        "semver": "^7.1.3",
+        "ssri": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "3.1.1",
+      "integrity": "sha512-XpJpsc7cg7+gdsC5IglXrPjeGzJh+GLhy8yLv4iKPhUFoe1s7dQvhsP5lN7YF0T98WwdEoMkKmbRJRCjEn3pEw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "npm-registry-fetch": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "2.0.3",
+      "integrity": "sha512-bCNyYddHmvGEfxOYIk5WcdWHXHIygfAo5tmcGf19YyIG42igd0+CckpuXXJgtIAMZSTFhwskWx9YZ9CmWL94CA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmversion": {
+      "version": "1.2.0",
+      "integrity": "sha512-0pfmobLZbOvq1cLIONZk8ISvEM1k3JdkNXWhMDZvUeH+ijBNvMVdPu/CPUr1eDFbNINS3b6R/0PbTIZDVz7thg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/git": "^2.0.7",
+        "@npmcli/run-script": "^1.8.4",
+        "json-parse-even-better-errors": "^2.3.1",
+        "semver": "^7.3.5",
+        "stringify-package": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "8.0.14",
+      "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.0.5",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^5.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/mime-db": {
+      "version": "1.47.0",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/mime-types": {
+      "version": "2.1.30",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "mime-db": "1.47.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/minimatch": {
+      "version": "3.0.4",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/minipass": {
+      "version": "3.1.3",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-fetch": {
+      "version": "1.3.3",
+      "integrity": "sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-json-stream": {
+      "version": "1.0.1",
+      "integrity": "sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "jsonparse": "^1.3.1",
+        "minipass": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minizlib": {
+      "version": "2.1.2",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp-infer-owner": {
+      "version": "2.0.0",
+      "integrity": "sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/ms": {
+      "version": "2.1.3",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/node-gyp": {
+      "version": "7.1.2",
+      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "tar": "^6.0.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "5.0.0",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "3.0.2",
+      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "2.1.5",
+      "integrity": "sha512-YB8qOoEmBhUH1UJgh1xFAv7Jg1d+xoNhsDYiFQlEFThEBui0W1vIz2ZK6FVg4WZjwEdl7uBQlm1jy3MUfyHeEw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "4.0.0",
+      "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "8.1.2",
+      "integrity": "sha512-6Eem455JsSMJY6Kpd3EyWE+n5hC+g9bSyHr9K9U2zqZb7+02+hObQ2c0+8iDk/mNF+8r1MhY44WypKJAkySIYA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "2.2.2",
+      "integrity": "sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "glob": "^7.1.6",
+        "ignore-walk": "^3.0.3",
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "6.1.1",
+      "integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "npm-install-checks": "^4.0.0",
+        "npm-normalize-package-bin": "^1.0.1",
+        "npm-package-arg": "^8.1.2",
+        "semver": "^7.3.4"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "5.0.3",
+      "integrity": "sha512-fZbRtN7JyEPBkdr+xLlj0lQrNI42TKlw/3EvEB7OzrwiUNl4veHsu2u06N2MrF5EiQbNUuZ54156Qr1K4R+91w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "npm-registry-fetch": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "10.1.2",
+      "integrity": "sha512-KsM/TdPmntqgBFlfsbkOLkkE9ovZo7VpVcd+/eTdYszCrgy5zFl5JzWm+OxavFaEWlbkirpkou+ZYI00RmOBFA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0",
+        "make-fetch-happen": "^8.0.9",
+        "minipass": "^3.1.3",
+        "minipass-fetch": "^1.3.0",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.0.0",
+        "npm-package-arg": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/npmlog": {
+      "version": "4.1.2",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/object-assign": {
+      "version": "4.1.1",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/p-map": {
+      "version": "4.0.0",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/pacote": {
+      "version": "11.3.3",
+      "integrity": "sha512-GQxBX+UcVZrrJRYMK2HoG+gPeSUX/rQhnbPkkGrCYa4n2F/bgClFPaMm0nsdnYrxnmUy85uMHoFXZ0jTD0drew==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "@npmcli/git": "^2.0.1",
+        "@npmcli/installed-package-contents": "^1.0.6",
+        "@npmcli/promise-spawn": "^1.2.0",
+        "@npmcli/run-script": "^1.8.2",
+        "cacache": "^15.0.5",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.3",
+        "mkdirp": "^1.0.3",
+        "npm-package-arg": "^8.0.1",
+        "npm-packlist": "^2.1.4",
+        "npm-pick-manifest": "^6.0.0",
+        "npm-registry-fetch": "^10.0.0",
+        "promise-retry": "^2.0.1",
+        "read-package-json-fast": "^2.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.0"
+      },
+      "bin": {
+        "pacote": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/parse-conflict-json": {
+      "version": "1.1.1",
+      "integrity": "sha512-4gySviBiW5TRl7XHvp1agcS7SOe0KZOjC//71dzZVWJrY9hCrgtvl5v3SyIxCZ4fZF47TxD9nfzmxcx76xmbUw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "just-diff": "^3.0.1",
+        "just-diff-apply": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-parse": {
+      "version": "1.0.6",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/performance-now": {
+      "version": "2.1.0",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/proc-log": {
+      "version": "1.0.0",
+      "integrity": "sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "dev": true,
+      "inBundle": true,
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/promise-call-limit": {
+      "version": "1.0.1",
+      "integrity": "sha512-3+hgaa19jzCGLuSCbieeRsu5C2joKfYn8pY6JAuXFRVfF4IO+L7UPpFWNTeWT9pM7uhskvbPPd/oEOktCn317Q==",
+      "dev": true,
+      "inBundle": true,
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/promise-retry": {
+      "version": "2.0.1",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/npm/node_modules/psl": {
+      "version": "1.8.0",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/punycode": {
+      "version": "2.1.1",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/npm/node_modules/qs": {
+      "version": "6.5.2",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/npm/node_modules/read": {
+      "version": "1.0.7",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "2.0.0",
+      "integrity": "sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/read-package-json": {
+      "version": "3.0.1",
+      "integrity": "sha512-aLcPqxovhJTVJcsnROuuzQvv6oziQx4zd3JvG0vGCL5MjTONUc4uJ90zCBC6R7W7oUKBNoR/F8pkyfVwlbxqng==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^3.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json-fast": {
+      "version": "2.0.2",
+      "integrity": "sha512-5fyFUyO9B799foVk4n6ylcoAktG/FbE3jwRKxvwaeSrIunaoMc0u81dzXxjeAFKOce7O5KncdfwpGvvs6r5PsQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/request": {
+      "version": "2.88.2",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/resolve": {
+      "version": "1.20.0",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf": {
+      "version": "3.0.2",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/semver": {
+      "version": "7.3.5",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "3.0.3",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.1.0",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks": {
+      "version": "2.6.1",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "5.0.0",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.7",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/sshpk": {
+      "version": "1.16.1",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ssri": {
+      "version": "8.0.1",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/string-width": {
+      "version": "2.1.1",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/stringify-package": {
+      "version": "1.0.1",
+      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "7.2.0",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/tar": {
+      "version": "6.1.0",
+      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/treeverse": {
+      "version": "1.0.4",
+      "integrity": "sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-filename": {
+      "version": "1.1.1",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-slug": {
+      "version": "2.0.2",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js": {
+      "version": "4.4.1",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/uuid": {
+      "version": "3.4.0",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "inBundle": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/verror": {
+      "version": "1.10.0",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/walk-up-path": {
+      "version": "1.0.0",
+      "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/which": {
+      "version": "2.0.2",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.3",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "4.0.0",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "inBundle": true
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ow": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.15.1.tgz",
+      "integrity": "sha512-rwiuvCnk3Ug9T4s5oKzw3QXQSiTXlTUiQgHmZ9Ozw/37YzeX8LycosVKOtO3v5+fuARGmCgz9rVhaBJeGV+2bQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ow/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-memoize": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-3.1.0.tgz",
+      "integrity": "sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==",
+      "dev": true,
+      "dependencies": {
+        "mem": "^4.3.0",
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
+      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout/node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "dependencies": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module/node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pascal-case/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-type/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "dependencies": {
+        "node-modules-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-conf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/prompts": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+      "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "dev": true,
+      "dependencies": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+      "dev": true,
+      "dependencies": {
+        "regenerate": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
+    },
+    "node_modules/regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+      "dev": true
+    },
+    "node_modules/regjsparser": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
+      "integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
+      "dev": true,
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.1.2.tgz",
+      "integrity": "sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==",
+      "dev": true
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      }
+    },
+    "node_modules/rollup-plugin-babel": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
+      "integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "7 || ^7.0.0-rc.2",
+        "rollup": ">=0.60.0 <3"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scoped-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-2.1.0.tgz",
+      "integrity": "sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release": {
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.3.tgz",
+      "integrity": "sha512-lTOUSrkbaQ+TRs3+BmtJhLtPSyiO7iTGmh5SyuEFqNO8HQbQ4nzXg4UlPrDQasO/C0eFK/V0eCbOzJdjtKBOYw==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/commit-analyzer": "^8.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^7.0.0",
+        "@semantic-release/npm": "^7.0.0",
+        "@semantic-release/release-notes-generator": "^9.0.0",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^7.0.0",
+        "debug": "^4.0.0",
+        "env-ci": "^5.0.0",
+        "execa": "^5.0.0",
+        "figures": "^3.0.0",
+        "find-versions": "^4.0.0",
+        "get-stream": "^6.0.0",
+        "git-log-parser": "^1.2.0",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^4.0.0",
+        "lodash": "^4.17.21",
+        "marked": "^2.0.0",
+        "marked-terminal": "^4.1.1",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.2",
+        "semver-diff": "^3.1.1",
+        "signale": "^1.2.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "semantic-release": "bin/semantic-release.js"
+      },
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
+    "node_modules/semantic-release-plugin-update-version-in-files": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release-plugin-update-version-in-files/-/semantic-release-plugin-update-version-in-files-1.1.0.tgz",
+      "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.3"
+      }
+    },
+    "node_modules/semantic-release/node_modules/cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/execa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/semver-diff/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "dependencies": {
+        "semver": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/semver-regex": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "node_modules/signale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.3.2",
+        "figures": "^2.0.0",
+        "pkg-conf": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/signale/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-keys/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-error-forwarder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
+      "dev": true
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
+      "dev": true
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/standard-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/standard-pkg/-/standard-pkg-0.5.0.tgz",
+      "integrity": "sha512-7w+8qU4hBMXeh5GmUTG39ODsqdaWrNZ8nq1gpPZu990DjuGVY6eCAhrcY+zFGc5OWlANqlF0XVArSU38J3HUUQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.2.2",
+        "@babel/parser": "^7.1.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-import-meta": "^7.2.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/traverse": "^7.1.5",
+        "@pika/babel-plugin-esm-import-rewrite": "^0.6.1",
+        "@types/minimist": "^1.2.0",
+        "chalk": "^2.1.0",
+        "glob": "^7.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1"
+      },
+      "bin": {
+        "standard-pkg": "dist-node/index.bin.js"
+      }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/stream-combiner2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-to-jsdoc-comment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-to-jsdoc-comment/-/string-to-jsdoc-comment-1.0.0.tgz",
+      "integrity": "sha512-jM0dXrYwDz+DOqILr06/LuaSI1F4Du/zwiSARyBehx4U5L3ztcLR+2UUIt4vUjtvxCc5YUWbHeSQkW/SxVbXUA==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
+      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "dev": true,
+      "dependencies": {
+        "del": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy/node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy/node_modules/del": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/globby": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "dependencies": {
+        "execa": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/term-size/node_modules/execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size/node_modules/get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/term-size/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/term-size/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size/node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/term-size/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/term-size/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/term-size/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/term-size/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "node_modules/terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-extensions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/throat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
+      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/tlds": {
+      "version": "1.221.1",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.221.1.tgz",
+      "integrity": "sha512-N1Afn/SLeOQRpxMwHBuNFJ3GvGrdtY4XPXKPFcx8he0U9Jg9ZkvTKE1k3jQDtCmlFn44UxjVtouF6PT4rEGd3Q==",
+      "dev": true,
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "node_modules/trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/trim-off-newlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.1.tgz",
+      "integrity": "sha512-03qAt77QjhxyM5Bt2KrrT1WbdumiwLz989sD3IUznSp3GIFQrx76kQqSMLF7ynnxrF3/1ipzABnHxMlU8PD4Vw==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0",
+        "typescript": ">=3.8 <5.0"
+      }
+    },
+    "node_modules/ts-jest/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
+      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-notifier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+      "dev": true,
+      "dependencies": {
+        "boxen": "^3.0.0",
+        "chalk": "^2.0.1",
+        "configstore": "^4.0.0",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^3.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/update-notifier/node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/update-notifier/node_modules/is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/update-notifier/node_modules/is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "dependencies": {
+        "path-is-inside": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/url-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
+      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
+      "dev": true,
+      "dependencies": {
+        "ip-regex": "^4.1.0",
+        "tlds": "^1.203.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
+      "integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/v8-to-istanbul/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/value-or-promise": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
+      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
+      "dependencies": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "dependencies": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
   "dependencies": {
     "@ardatan/aggregate-error": {
       "version": "0.0.6",
@@ -2214,7 +20939,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.3.0",
@@ -2296,7 +21022,7 @@
       "integrity": "sha512-ernb1SHzvk1Mfi8pBVRAaCKtavz80IiIXG5kOuHsM9+ICxspypR6f7kdFWvglJjVhhdBrYSnecFK7W28fZCXjQ==",
       "dev": true,
       "requires": {
-        "@pika/cli": "^0.2.0",
+        "@pika/cli": "latest",
         "@pika/types": "^0.6.0",
         "chalk": "^2.1.0",
         "commander": "^2.9.0",
@@ -2842,16 +21568,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
     },
     "abab": {
       "version": "2.0.5",
@@ -3966,8 +22682,8 @@
       "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -7715,7 +26431,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.0.1",
@@ -8758,6 +27475,16 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -9027,6 +27754,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.capitalize": {
@@ -11572,6 +30305,14 @@
             "minipass": "^3.1.1"
           }
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
@@ -11594,14 +30335,6 @@
                 "ansi-regex": "^3.0.0"
               }
             }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -13294,6 +32027,23 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -13314,6 +32064,12 @@
           }
         }
       }
+    },
+    "string-to-jsdoc-comment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-to-jsdoc-comment/-/string-to-jsdoc-comment-1.0.0.tgz",
+      "integrity": "sha512-jM0dXrYwDz+DOqILr06/LuaSI1F4Du/zwiSARyBehx4U5L3ztcLR+2UUIt4vUjtvxCc5YUWbHeSQkW/SxVbXUA==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.2",
@@ -13366,23 +32122,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {
@@ -14295,7 +33034,8 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "jest --coverage",
     "update-endpoints": "npm-run-all update-endpoints:*",
     "update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
-    "update-endpoints:code": "node scripts/update-endpoints/code"
+    "update-endpoints:code": "node scripts/update-endpoints/code",
+    "update-endpoints:types": "node scripts/update-endpoints/types"
   },
   "repository": "github:octokit/plugin-enterprise-server.js",
   "keywords": [
@@ -44,11 +45,13 @@
     "fetch-mock": "^9.0.0",
     "github-openapi-graphql-query": "^1.0.5",
     "jest": "^27.0.0",
+    "lodash.camelcase": "^4.3.0",
     "npm-run-all": "^4.1.5",
     "prettier": "2.3.2",
     "semantic-release": "^17.0.0",
     "semantic-release-plugin-update-version-in-files": "^1.0.0",
     "sort-keys": "^4.2.0",
+    "string-to-jsdoc-comment": "^1.0.0",
     "ts-jest": "^27.0.0-next.12",
     "typescript": "^4.0.2"
   },

--- a/scripts/update-endpoints/code.js
+++ b/scripts/update-endpoints/code.js
@@ -110,16 +110,19 @@ async function generateRoutes() {
       (version) => `
         import ENDPOINTS_${version} from "./generated/ghe-${version}-endpoints";
         import ADMIN_ENDPOINTS_${version} from "./generated/ghe-${version}-admin-endpoints";
+        import { RestEndpointMethods as RestEndpointMethods_${version} } from "./generated/ghe-${version}-method-types";
       `
     ).join("\n");
     const methods = GHE_VERSIONS.map(
       (version) => `
-        export function enterpriseServer${version}Admin(octokit: Octokit) {
+        export function enterpriseServer${version}Admin(octokit: Octokit): { enterpriseAdmin: RestEndpointMethods_${version}["enterpriseAdmin"] } {
+          // @ts-ignore - not worth the hassle
           return endpointsToMethods(octokit, ADMIN_ENDPOINTS_${version});
         }
         enterpriseServer${version}Admin.VERSION = VERSION;
 
-        export function enterpriseServer${version}(octokit: Octokit) {
+        export function enterpriseServer${version}(octokit: Octokit): RestEndpointMethods_${version} {
+          // @ts-ignore - not worth the hassle
           return endpointsToMethods(octokit, ENDPOINTS_${version});
         }
         enterpriseServer${version}.VERSION = VERSION;

--- a/scripts/update-endpoints/types.js
+++ b/scripts/update-endpoints/types.js
@@ -1,0 +1,191 @@
+const { writeFileSync } = require("fs");
+const { join: pathJoin } = require("path");
+
+const camelCase = require("lodash.camelcase");
+const prettier = require("prettier");
+const { stringToJsdocComment } = require("string-to-jsdoc-comment");
+const sortKeys = require("sort-keys");
+
+const GHE_VERSIONS = require("./ghe-versions");
+const { isDeprecated } = require("./util");
+
+generateTypes();
+
+async function generateTypes() {
+  for (const version of GHE_VERSIONS) {
+    const ROUTES = await getRoutes(version);
+
+    const namespaces = Object.keys(ROUTES).reduce((namespaces, namespace) => {
+      const methods = Object.keys(ROUTES[namespace]).reduce(
+        (methods, methodName) => {
+          const entry = ROUTES[namespace][methodName];
+
+          const description = [
+            entry.description,
+            entry.deprecated && `@deprecated ${entry.deprecated}`,
+          ]
+            .filter(Boolean)
+            .join("\n");
+
+          return methods.concat({
+            name: methodName,
+            route: `${entry.method} ${entry.url}`,
+            hasRequiredPreviews: entry.hasRequiredPreviews,
+            jsdoc: stringToJsdocComment(description),
+          });
+        },
+        []
+      );
+
+      return namespaces.concat({
+        namespace: camelCase(namespace),
+        methods,
+      });
+    }, []);
+
+    const RestEndpointMethodParameterAndResponseTypes = [];
+    for (const namespace of namespaces) {
+      const namespaceMethods = [];
+      for (const method of namespace.methods) {
+        namespaceMethods.push(
+          `${method.name}: {
+          parameters: RequestParameters & Omit<Endpoints["${method.route}"]["parameters"], "baseUrl" | "headers" | "mediaType">,
+          response: Endpoints["${method.route}"]["response"]
+        }`
+        );
+      }
+
+      RestEndpointMethodParameterAndResponseTypes.push(`${
+        namespace.namespace
+      }: {
+      ${namespaceMethods.join("\n")}
+    }`);
+    }
+
+    const RestEndpointMethodNamespaceTypes = [];
+    for (const namespace of namespaces) {
+      const namespaceMethods = [];
+      for (const method of namespace.methods) {
+        namespaceMethods.push(
+          [
+            method.jsdoc,
+            `${method.name}: {
+          (params?: RestEndpointMethodTypes["${namespace.namespace}"]["${method.name}"]["parameters"]): Promise<RestEndpointMethodTypes["${namespace.namespace}"]["${method.name}"]["response"]>
+          defaults: RequestInterface["defaults"];
+          endpoint: EndpointInterface<{ url: string }>;
+        }`,
+          ].join("\n")
+        );
+      }
+
+      RestEndpointMethodNamespaceTypes.push(`${namespace.namespace}: {
+      ${namespaceMethods.join("\n")}
+    }`);
+    }
+
+    const methodTypesSource = prettier.format(
+      [
+        `import { EndpointInterface, RequestInterface } from "@octokit/types";`,
+        `import { RestEndpointMethodTypes } from "./ghe-${version}-parameters-and-response-types";`,
+        "",
+        `export type RestEndpointMethods = {
+        ${RestEndpointMethodNamespaceTypes.join("\n")}
+      }`,
+      ].join("\n"),
+      {
+        parser: "typescript",
+      }
+    );
+    const parametersAndResponsesTypes = prettier.format(
+      [
+        `import { Endpoints, RequestParameters } from "@octokit/types";`,
+        "",
+        `export type RestEndpointMethodTypes = {
+        ${RestEndpointMethodParameterAndResponseTypes.join("\n")}
+      }`,
+      ].join("\n"),
+      {
+        parser: "typescript",
+      }
+    );
+
+    const methodTypesFilePath = pathJoin(
+      process.cwd(),
+      "src",
+      "generated",
+      `ghe-${version}-method-types.ts`
+    );
+
+    writeFileSync(methodTypesFilePath, methodTypesSource, "utf8");
+    console.log(`Types written to ${methodTypesFilePath}`);
+
+    const parametersAndResponseFilePath = pathJoin(
+      process.cwd(),
+      "src",
+      "generated",
+      `ghe-${version}-parameters-and-response-types.ts`
+    );
+
+    writeFileSync(
+      parametersAndResponseFilePath,
+      parametersAndResponsesTypes,
+      "utf8"
+    );
+    console.log(`Types written to ${parametersAndResponseFilePath}`);
+  }
+}
+
+async function getRoutes(version) {
+  const newRoutes = {};
+  const ENDPOINTS = require(`./generated/ghe${version}-endpoints.json`);
+
+  ENDPOINTS.forEach((endpoint) => {
+    if (isDeprecated(endpoint)) return;
+
+    const scope = endpoint.scope;
+
+    if (!newRoutes[scope]) {
+      newRoutes[scope] = {};
+    }
+
+    const idName = endpoint.id;
+    const url = endpoint.url
+      .toLowerCase()
+      // stecial case for "Upload a release asset": remove ":origin" prefix
+      .replace(/^:origin/, "");
+
+    // new route
+    newRoutes[scope][idName] = {
+      method: endpoint.method,
+      url,
+      description: endpoint.description,
+      hasRequiredPreviews: !!endpoint.previews.length,
+      deprecated: newRoutes[scope][idName]
+        ? newRoutes[scope][idName].deprecated
+        : undefined,
+    };
+
+    if (endpoint.renamed) {
+      const { before, after } = endpoint.renamed;
+      if (!newRoutes[before.scope]) {
+        newRoutes[before.scope] = {};
+      }
+
+      if (!newRoutes[before.scope][before.id]) {
+        newRoutes[before.scope][before.id] = newRoutes[scope][idName];
+      }
+
+      newRoutes[before.scope][
+        before.id
+      ].deprecated = `octokit.rest.${before.scope}.${before.id}() has been renamed to octokit.rest.${after.scope}.${after.id}() (${endpoint.renamed.date})`;
+    }
+
+    if (endpoint.isDeprecated) {
+      newRoutes[scope][
+        idName
+      ].deprecated = `octokit.rest.${scope}.${idName}() is deprecated, see ${endpoint.documentationUrl}`;
+    }
+  });
+
+  return sortKeys(newRoutes, { deep: true });
+}

--- a/scripts/update-endpoints/util.js
+++ b/scripts/update-endpoints/util.js
@@ -1,0 +1,28 @@
+module.exports = {
+  isDeprecated,
+};
+
+/**
+ * we ignore all legacy endpoints except the ones that were recently added
+ * @param { Endpoint } endpoint
+ */
+function isDeprecated(endpoint) {
+  const deprecated = endpoint.isLegacy || endpoint.isDeprecated;
+
+  if (!deprecated) {
+    return false;
+  }
+
+  // if (endpoint.isLegacy && /^\/teams\/\{team_id\}/.test(endpoint.url)) {
+  //   return false;
+  // }
+
+  if (
+    endpoint.method === "DELETE" &&
+    endpoint.url === "/reactions/{reaction_id}"
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/generated/ghe-220-method-types.ts
+++ b/src/generated/ghe-220-method-types.ts
@@ -1,0 +1,6366 @@
+import { EndpointInterface, RequestInterface } from "@octokit/types";
+import { RestEndpointMethodTypes } from "./ghe-220-parameters-and-response-types";
+
+export type RestEndpointMethods = {
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#set-a-repository-subscription).
+     */
+    deleteRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Mutes all future notifications for a conversation until you comment on the thread or get an **@mention**. If you are watching the repository of the thread, you will still receive notifications. To ignore future notifications for a repository you are watching, use the [Set a thread subscription](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#set-a-thread-subscription) endpoint and set `ignore` to `true`.
+     */
+    deleteThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * GitHub Enterprise Server provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:
+     *
+     * *   **Timeline**: The GitHub Enterprise Server global public timeline
+     * *   **User**: The public timeline for any user, using [URI template](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#hypermedia)
+     * *   **Current user public**: The public timeline for the authenticated user
+     * *   **Current user**: The private timeline for the authenticated user
+     * *   **Current user actor**: The private timeline for activity created by the authenticated user
+     * *   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
+     * *   **Security advisories**: A collection of public announcements that provide information about security-related vulnerabilities in software on GitHub Enterprise Server.
+     *
+     * **Note**: Private feeds are only returned when [authenticating via Basic Auth](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication) since current feed URIs use the older, non revocable auth tokens.
+     */
+    getFeeds: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getFeeds"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getFeeds"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getThread: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThread"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getThread"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This checks to see if the current user is subscribed to a thread. You can also [get a repository subscription](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#get-a-repository-subscription).
+     *
+     * Note that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mentioned**, or manually subscribe to a thread.
+     */
+    getThreadSubscriptionForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+     */
+    listEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user, sorted by most recently updated.
+     */
+    listNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This is the user's organization dashboard. You must be authenticated as the user to view this.
+     */
+    listOrgEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * We delay the public events feed by five minutes, which means the most recent event returned by the public events API actually occurred at least five minutes ago.
+     */
+    listPublicEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForRepoNetwork: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicOrgEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.
+     */
+    listReceivedEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReceivedPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRepoEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user.
+     */
+    listRepoNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user is watching.
+     */
+    listReposWatchedByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people that have starred the repository.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/) via the `Accept` header:
+     */
+    listStargazersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user is watching.
+     */
+    listWatchedReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people watching the specified repository.
+     */
+    listWatchersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications as "read" removes it from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List notifications for the authenticated user](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#list-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications in a repository as "read" removes them from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List repository notifications for the authenticated user](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#list-repository-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markRepoNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    markThreadAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markThreadAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markThreadAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#delete-a-repository-subscription) completely.
+     */
+    setRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are watching a repository, you receive notifications for all threads by default. Use this endpoint to ignore future notifications for threads until you comment on the thread or get an **@mention**.
+     *
+     * You can also use this endpoint to subscribe to threads that you are currently not receiving notifications for or to subscribed to threads that you have previously ignored.
+     *
+     * Unsubscribing from a conversation in a repository that you are not watching is functionally equivalent to the [Delete a thread subscription](https://docs.github.com/enterprise-server@2.20/rest/reference/activity#delete-a-thread-subscription) endpoint.
+     */
+    setThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    starRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstarRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  apps: {
+    /**
+     * Add a single repository to an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@2.20/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    addRepoToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication) to use this endpoint, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.
+     */
+    checkToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["checkToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["checkToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated:** use `apps.createContentAttachmentForRepo()` (`POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments`) instead. Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://docs.github.com/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachment: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` and `repository` `full_name` of the content reference from the [`content_reference` event](https://docs.github.com/enterprise-server@2.20/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/enterprise-server@2.20/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachmentForRepo: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.
+     */
+    createFromManifest: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createFromManifest"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createFromManifest"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an installation access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token. By default the installation token has access to all repositories that the installation can access. To restrict the access to specific repositories, you can provide the `repository_ids` when creating the token. When you omit `repository_ids`, the response does not contain the `repositories` key.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    createInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid OAuth `access_token` as an input parameter and the grant for the token's owner will be deleted.
+     * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+     */
+    deleteAuthorization: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteAuthorization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteAuthorization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uninstalls a GitHub App on a user, organization, or business account. You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    deleteInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+     */
+    deleteToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["deleteToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the "[List installations for the authenticated app](https://docs.github.com/enterprise-server@2.20/rest/reference/apps#list-installations-for-the-authenticated-app)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).
+     *
+     * If the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    getBySlug: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getBySlug"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["getBySlug"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find an installation's information using the installation id. The installation's account type (`target_type`) will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the organization's installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getOrgInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getOrgInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getOrgInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getRepoInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getRepoInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getRepoInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the user’s installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getUserInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getUserInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getUserInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The access the user has to each repository is included in the hash under the `permissions` key.
+     */
+    listInstallationReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     *
+     * The permissions the installation has are included under the `permissions` key.
+     */
+    listInstallations: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You can find the permissions for the installation under the `permissions` key.
+     */
+    listInstallationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that an app installation can access.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    listReposAccessibleToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Remove a single repository from an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@2.20/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    removeRepoFromInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    resetToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["resetToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["resetToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Revokes the installation token you're using to authenticate as an installation and access this endpoint.
+     *
+     * Once an installation token is revoked, the token is invalidated and cannot be used. Other endpoints that require the revoked installation token must have a new installation token to work. You can create a new token using the "[Create an installation access token for an app](https://docs.github.com/enterprise-server@2.20/rest/reference/apps#create-an-installation-access-token-for-an-app)" endpoint.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    revokeInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  checks: {
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Creates a new check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to create check runs.
+     *
+     * In a check suite, GitHub limits the number of check runs with the same name to 1000. Once these check runs exceed 1000, GitHub will start to automatically delete older check runs.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * By default, check suites are automatically created when you create a [check run](https://docs.github.com/enterprise-server@2.20/rest/reference/checks#check-runs). You only need to use this endpoint for manually creating check suites when you've disabled automatic creation using "[Update repository preferences for check suites](https://docs.github.com/enterprise-server@2.20/rest/reference/checks#update-repository-preferences-for-check-suites)". Your GitHub App must have the `checks:write` permission to create check suites.
+     */
+    createSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["createSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["createSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    getSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["getSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["getSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.
+     */
+    listAnnotations: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listAnnotations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listAnnotations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    listSuitesForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listSuitesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listSuitesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository. This endpoint will trigger the [`check_suite` webhook](https://docs.github.com/enterprise-server@2.20/webhooks/event-payloads/#check_suite) event with the action `rerequested`. When a check suite is `rerequested`, its `status` is reset to `queued` and the `conclusion` is cleared.
+     *
+     * To rerequest a check suite, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.
+     */
+    rerequestSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["rerequestSuite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["rerequestSuite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://docs.github.com/enterprise-server@2.20/rest/reference/checks#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.
+     */
+    setSuitesPreferences: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Updates a check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to edit check runs.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getConductCode: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  emojis: {
+    /**
+     * Lists all the emojis available to use on GitHub Enterprise Server.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["emojis"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["emojis"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you boot a GitHub instance for the first time, you can use the following endpoint to upload a license:
+     *
+     * Note that you need to POST to [`/setup/api/configure`](https://docs.github.com/enterprise-server@2.20/rest/reference/enterprise-admin#start-a-configuration-process) to start the actual configuration process.
+     *
+     * When using this endpoint, your GitHub instance must have a password set. This can be accomplished two ways:
+     *
+     * 1.  If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
+     * 2.  If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
+     *
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@2.20/rest/reference/enterprise-admin#get-settings).
+     */
+    createEnterpriseServerLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If an external authentication mechanism is used, the login name should match the login name in the external system. If you are using LDAP authentication, you should also [update the LDAP mapping](https://docs.github.com/enterprise-server@2.20/rest/reference/enterprise-admin#update-ldap-mapping-for-a-user) for the user.
+     *
+     * The login name will be normalized to only contain alphanumeric characters or single hyphens. For example, if you send `"octo_cat"` as the login, a user named `"octo-cat"` will be created.
+     *
+     * If the login name or email address is already associated with an account, the server will return a `422` response.
+     */
+    createUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a personal access token. Returns a `403 - Forbidden` status when a personal access token is in use. For example, if you access this endpoint with the same personal access token that you are trying to delete, you will receive this error.
+     */
+    deletePersonalAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you attempt to delete an environment that cannot be deleted, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * *   _Cannot modify or delete the default environment_
+     * *   _Cannot delete environment that has hooks_
+     * *   _Cannot delete environment when download is in progress_
+     */
+    deletePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePublicKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a user will delete all their repositories, gists, applications, and personal settings. [Suspending a user](https://docs.github.com/enterprise-server@2.20/rest/reference/enterprise-admin#suspend-a-user) is often a better option.
+     *
+     * You can delete any user account except your own.
+     */
+    deleteUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can demote any user account except your own.
+     */
+    demoteSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The possible values for `enabled` are `true` and `false`. When it's `false`, the attribute `when` is ignored and the maintenance mode is turned off. `when` defines the time period when the maintenance was enabled.
+     *
+     * The possible values for `when` are `now` or any date parseable by [mojombo/chronic](https://github.com/mojombo/chronic).
+     */
+    enableOrDisableMaintenanceMode: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllAuthorizedSshKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommentStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to check the status of the most recent configuration process:
+     *
+     * Note that you may need to wait several seconds after you start a process before you can check its status.
+     *
+     * The different statuses are:
+     *
+     * | Status        | Description                       |
+     * | ------------- | --------------------------------- |
+     * | `PENDING`     | The job has not started yet       |
+     * | `CONFIGURING` | The job is running                |
+     * | `DONE`        | The job has finished correctly    |
+     * | `FAILED`      | The job has finished unexpectedly |
+     */
+    getConfigurationStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In addition to seeing the download status at the "[Get a pre-receive environment](#get-a-pre-receive-environment)" endpoint, there is also this separate endpoint for just the download status.
+     */
+    getDownloadStatusForPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getHooksStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getIssueStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLicenseInformation: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Check your installation's maintenance status:
+     */
+    getMaintenanceStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestoneStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getOrgStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPullRequestStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getUserStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listGlobalWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists personal access tokens for all users, including admin users.
+     */
+    listPersonalAccessTokens: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveEnvironments: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveHooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this organization as well as any disabled hooks that can be configured at the organization level. Globally disabled pre-receive hooks that do not allow downstream configuration are not listed.
+     */
+    listPreReceiveHooksForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this repository as well as any disabled hooks that are allowed to be enabled at the repository level. Pre-receive hooks that are disabled at a higher level and are not configurable will not be listed.
+     */
+    listPreReceiveHooksForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.20/webhooks/#ping-event) to be sent to the webhook.
+     */
+    pingGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    promoteUserToBeSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any overrides for this hook at the org level for this org.
+     */
+    removePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes any overridden enforcement on this repository for the specified hook.
+     *
+     * Responds with effective values inherited from owner and/or global level.
+     */
+    removePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@2.20/rest/reference/enterprise-admin#get-settings).
+     */
+    setSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to start a configuration process at any time for your updated settings to take effect:
+     */
+    startConfigurationProcess: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers a new download of the environment tarball from the environment's `image_url`. When the download is finished, the newly downloaded tarball will overwrite the existing environment.
+     *
+     * If a download cannot be triggered, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * * _Cannot modify or delete the default environment_
+     * * _Can not start a new download when a download is in progress_
+     */
+    startPreReceiveEnvironmentDownload: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), Active Directory LDAP-authenticated users cannot be suspended through this API. If you attempt to suspend an Active Directory LDAP-authenticated user through this API, it will return a `403` response.
+     *
+     * You can suspend any user account except your own.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    suspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), this API is disabled and will return a `403` response. Active Directory LDAP-authenticated users cannot be unsuspended using the API.
+     */
+    unsuspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Parameters that are not provided will be overwritten with the default value or removed if no default exists.
+     */
+    updateGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the [distinguished name](https://www.ldap.com/ldap-dns-and-rdns) (DN) of the LDAP entry to map to a team. [LDAP synchronization](https://help.github.com/enterprise/admin/guides/user-management/using-ldap/#enabling-ldap-sync) must be enabled to map LDAP entries to a team. Use the [Create a team](https://docs.github.com/enterprise-server@2.20/rest/reference/teams/#create-a-team) endpoint to create a team with LDAP mapping.
+     *
+     * You can also update the LDAP mapping of a child team.
+     */
+    updateLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateOrgName: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You cannot modify the default environment. If you attempt to modify the default environment, you will receive a `422 Unprocessable Entity` response.
+     */
+    updatePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updatePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the org level, you can set `enforcement` and `allow_downstream_configuration`
+     */
+    updatePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the repo level, you can set `enforcement`
+     */
+    updatePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateUsernameForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This API upgrades your license and also triggers the configuration process:
+     */
+    upgradeLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["checkIsStarred"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gists"]["checkIsStarred"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to add a new gist with one or more files.
+     *
+     * **Note:** Don't name your files "gistfile" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["createComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["createComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["deleteComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["deleteComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: This was previously `/gists/:gist_id/fork`.
+     */
+    fork: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["fork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["fork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    get: {
+      (params?: RestEndpointMethodTypes["gists"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["gists"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRevision: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getRevision"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getRevision"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the authenticated user's gists or if called anonymously, this endpoint returns all public gists:
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public gists for the specified user:
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List public gists sorted by most recently updated to least recently updated.
+     *
+     * Note: With [pagination](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the authenticated user's starred gists:
+     */
+    listStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listStarred"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listStarred"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    star: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["star"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["star"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstar: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["unstar"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["unstar"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to update or delete a gist file and rename gist files. Files from the previous version of the gist that aren't explicitly changed during an edit are unchanged.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["updateComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["updateComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  git: {
+    createBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reference for your repository. You are unable to create new references for empty repositories, even if the commit SHA-1 hash used exists. Empty repositories are repositories without branches.
+     */
+    createRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://docs.github.com/enterprise-server@2.20/rest/reference/git#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://docs.github.com/enterprise-server@2.20/rest/reference/git#create-a-reference) the tag reference - this call would be unnecessary.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The tree creation API accepts nested entries. If you specify both a tree and a nested path modifying that tree, this endpoint will overwrite the contents of the tree with the new path contents, and create a new tree structure.
+     *
+     * If you use this endpoint to add, delete, or modify the file contents in a tree, you will need to commit the tree and then update a branch to point to the commit. For more information see "[Create a commit](https://docs.github.com/enterprise-server@2.20/rest/reference/git#create-a-commit)" and "[Update a reference](https://docs.github.com/enterprise-server@2.20/rest/reference/git#update-a-reference)."
+     */
+    createTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["deleteRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["deleteRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `content` in the response will always be Base64 encoded.
+     *
+     * _Note_: This API supports blobs up to 100 megabytes in size.
+     */
+    getBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single reference from your Git database. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't match an existing ref, a `404` is returned.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.20/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     */
+    getRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single tree using the SHA1 value for that tree.
+     *
+     * If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+     */
+    getTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns an array of references from your Git database that match the supplied name. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't exist in the repository, but existing refs start with `:ref`, they will be returned as an array.
+     *
+     * When you use this endpoint without providing a `:ref`, it will return an array of all the references from your Git database, including notes and stashes if they exist on the server. Anything in the namespace is returned, not just `heads` and `tags`.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.20/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * If you request matching references for a branch named `feature` but the branch `feature` doesn't exist, the response can still include other matching head refs that start with the word `feature`, such as `featureA` and `featureB`.
+     */
+    listMatchingRefs: {
+      (
+        params?: RestEndpointMethodTypes["git"]["listMatchingRefs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["git"]["listMatchingRefs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["updateRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["updateRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gitignore: {
+    /**
+     * List all templates available to pass as an option when [creating a repository](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#create-a-repository-for-the-authenticated-user).
+     */
+    getAllTemplates: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API also allows fetching the source of a single template.
+     * Use the raw [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/) to get the raw contents.
+     */
+    getTemplate: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  issues: {
+    /**
+     * Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.
+     */
+    addAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addAssignees"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addAssignees"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    addLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks if a user has permission to be assigned to an issue in this repository.
+     *
+     * If the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.
+     *
+     * Otherwise a `404` status code is returned.
+     */
+    checkUserCanBeAssigned: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://help.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["createLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["deleteLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API returns a [`301 Moved Permanently` status](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-redirects-redirects) if the issue was
+     * [transferred](https://help.github.com/articles/transferring-an-issue-to-another-repository/) to another repository. If
+     * the issue was transferred to or deleted from a repository where the authenticated user lacks read access, the API
+     * returns a `404 Not Found` status. If the issue was deleted from a repository where the authenticated user has read
+     * access, the API returns a `410 Gone` status. To receive webhook events for transferred and deleted issues, subscribe
+     * to the [`issues`](https://docs.github.com/enterprise-server@2.20/webhooks/event-payloads/#issues) webhook.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getEvent: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getEvent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getEvent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getMilestone"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getMilestone"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues assigned to the authenticated user across all visible repositories including owned repositories, member
+     * repositories, and organization repositories. You can use the `filter` query parameter to fetch issues that are not
+     * necessarily assigned to you.
+     *
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.
+     */
+    listAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue Comments are ordered by ascending ID.
+     */
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * By default, Issue Comments are ordered by ascending ID.
+     */
+    listCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEvents: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEvents"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listEvents"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForTimeline: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues across owned and member repositories assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in an organization assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in a repository.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsOnIssue: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMilestones: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listMilestones"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listMilestones"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can lock an issue or pull request's conversation.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    lock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["lock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["lock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAllLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAllLabels"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAllLabels"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes one or more assignees from an issue.
+     */
+    removeAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the specified label from the issue, and returns the remaining labels on the issue. This endpoint returns a `404 Not Found` status if the label does not exist.
+     */
+    removeLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["removeLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any previous labels and sets the new labels for an issue.
+     */
+    setLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["setLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["setLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can unlock an issue's conversation.
+     */
+    unlock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["unlock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["unlock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue owners and users with push access can edit an issue.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  licenses: {
+    get: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllCommonlyUsed: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This method returns the contents of the repository's license file, if one is detected.
+     *
+     * Similar to [Get repository content](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#get-repository-content), this method also supports [custom media types](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types) for retrieving the raw license content or rendered license HTML.
+     */
+    getForRepo: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["getForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  markdown: {
+    render: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["render"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["render"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.
+     */
+    renderRaw: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["renderRaw"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["renderRaw"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  meta: {
+    get: {
+      (params?: RestEndpointMethodTypes["meta"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get the octocat as ASCII art
+     */
+    getOctocat: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getOctocat"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getOctocat"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a random sentence from the Zen of GitHub
+     */
+    getZen: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getZen"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getZen"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get Hypermedia links to resources accessible in GitHub's REST API
+     */
+    root: {
+      (params?: RestEndpointMethodTypes["meta"]["root"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["root"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  orgs: {
+    /**
+     * Check if a user is, publicly or privately, a member of the organization.
+     */
+    checkMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPublicMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see "[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)".
+     */
+    convertMemberToOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Here's how you can create a hook that posts payloads in JSON format:
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
+     *
+     * GitHub Apps with the `Organization plan` permission can use this endpoint to retrieve information about an organization's GitHub Enterprise Server plan. See "[Authenticating with GitHub Apps](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/authenticating-with-github-apps/)" for details. For an example response, see 'Response with GitHub Enterprise Server plan information' below."
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["orgs"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to get a user's membership with an organization, the authenticated user must be an organization member. The `state` parameter in the response can be used to identify the user's membership status.
+     */
+    getMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in an organization. To get only the webhook `config` properties, see "[Get a webhook configuration for an organization](/rest/reference/orgs#get-a-webhook-configuration-for-an-organization)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all organizations, in the order that they were created on GitHub Enterprise Server.
+     *
+     * **Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of organizations.
+     */
+    list: {
+      (params?: RestEndpointMethodTypes["orgs"]["list"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["list"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all GitHub Apps in an organization. The installation count includes all GitHub Apps installed on repositories in the organization. You must be an organization owner with `admin:read` scope to use this endpoint.
+     */
+    listAppInstallations: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listAppInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listAppInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List organizations for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * This only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.
+     *
+     * This method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List organizations for the authenticated user](https://docs.github.com/enterprise-server@2.20/rest/reference/orgs#list-organizations-for-the-authenticated-user) API instead.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
+     */
+    listMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembers"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listMembers"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMembershipsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are outside collaborators of an organization.
+     */
+    listOutsideCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Members of an organization can choose to have their membership publicized or not.
+     */
+    listPublicMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listPublicMembers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listPublicMembers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.20/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+     */
+    removeMember: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMember"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["removeMember"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to remove a user's membership with an organization, the authenticated user must be an organization owner.
+     *
+     * If the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.
+     */
+    removeMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all the organization's repositories.
+     */
+    removeOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removePublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Only authenticated organization owners can add a member to the organization or update the member's role.
+     *
+     * *   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](https://docs.github.com/enterprise-server@2.20/rest/reference/orgs#get-organization-membership-for-a-user) will be `pending` until they accept the invitation.
+     *
+     * *   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.
+     */
+    setMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The user can publicize their own membership. (A user cannot publicize the membership for another user.)
+     *
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    setPublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Parameter Deprecation Notice:** GitHub Enterprise Server will replace and discontinue `members_allowed_repository_creation_type` in favor of more granular permissions. The new input parameters are `members_can_create_public_repositories`, `members_can_create_private_repositories` for all organizations and `members_can_create_internal_repositories` for organizations associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. For more information, see the [blog post](https://developer.github.com/changes/2019-12-03-internal-visibility-changes).
+     *
+     * Enables an authenticated organization owner with the `admin:org` scope to update the organization's profile and member privileges.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in an organization. When you update a webhook, the `secret` will be overwritten. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for an organization](/rest/reference/orgs#update-a-webhook-configuration-for-an-organization)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  projects: {
+    /**
+     * Adds a collaborator to an organization project and sets their permission level. You must be an organization owner or a project `admin` to add a collaborator.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["createCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an organization project board. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a repository project board. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a project board. Returns a `404 Not Found` status if projects are disabled.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["deleteCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["deleteColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a project by its `id`. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the collaborator's permission level for an organization project. Possible values for the `permission` key: `admin`, `write`, `read`, `none`. You must be an organization owner or a project `admin` to review a user's permission level.
+     */
+    getPermissionForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getPermissionForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["getPermissionForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCards: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCards"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listCards"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listColumns: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listColumns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listColumns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a collaborator from an organization project. You must be an organization owner or a project `admin` to remove a collaborator.
+     */
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a project board's information. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["updateCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["updateColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["checkIfMerged"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["checkIfMerged"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team, GitHub Enterprise Server 2.17+, and GitHub Enterprise Cloud. You can create a new pull request. This endpoint triggers [notifications](https://docs.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reply to a review comment for a pull request. For the `comment_id`, provide the ID of the review comment you are replying to. This must be the ID of a _top-level review comment_, not a reply to that comment. Replies to replies are not supported.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReplyForReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * Pull request reviews created in the `PENDING` state do not include the `submitted_at` property in the response.
+     *
+     * **Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#get-a-pull-request) endpoint.
+     *
+     * The `position` value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     */
+    createReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["createReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a review comment in the pull request diff. To add a regular comment to a pull request timeline, see "[Create an issue comment](https://docs.github.com/enterprise-server@2.20/rest/reference/issues#create-an-issue-comment)." We recommend creating a review comment using `line`, `side`, and optionally `start_line` and `start_side` if your comment applies to more than one line in the pull request diff.
+     *
+     * You can still create a review comment using the `position` parameter. When you use `position`, the `line`, `side`, `start_line`, and `start_side` parameters are not required. For more information, see the [`comfort-fade` preview notice](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#create-a-review-comment-for-a-pull-request-preview-notices).
+     *
+     * **Note:** The position value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePendingReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deletePendingReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deletePendingReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a review comment.
+     */
+    deleteReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** To dismiss a pull request review on a [protected branch](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#branches), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.
+     */
+    dismissReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["dismissReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["dismissReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists details of a pull request by providing its number.
+     *
+     * When you get, [create](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls/#create-a-pull-request), or [edit](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#update-a-pull-request) a pull request, GitHub Enterprise Server creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.20/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub Enterprise Server has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the _test_ merge commit.
+     *
+     * The value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
+     *
+     * *   If merged as a [merge commit](https://help.github.com/articles/about-merge-methods-on-github/), `merge_commit_sha` represents the SHA of the merge commit.
+     * *   If merged via a [squash](https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits), `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
+     * *   If [rebased](https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits), `merge_commit_sha` represents the commit that the base branch was updated to.
+     *
+     * Pass the appropriate [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["pulls"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["pulls"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["getReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides details for a review comment.
+     */
+    getReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["getReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team, GitHub Enterprise Server 2.17+, and GitHub Enterprise Cloud.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List comments for a specific pull request review.
+     */
+    listCommentsForReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a maximum of 250 commits for a pull request. To receive a complete commit list for pull requests with more than 250 commits, use the [List commits](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#list-commits) endpoint.
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** Responses include a maximum of 3000 files. The paginated response returns 30 files per page by default.
+     */
+    listFiles: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listFiles"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
+     */
+    listReviewComments: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewComments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
+     */
+    listReviewCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The list of reviews returns in chronological order.
+     */
+    listReviews: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviews"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    requestReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["requestReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["requestReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    submitReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["submitReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["submitReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team, GitHub Enterprise Server 2.17+, and GitHub Enterprise Cloud.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch.
+     */
+    updateBranch: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Update the review summary comment with new text.
+     */
+    updateReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables you to edit a review comment.
+     */
+    updateReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["updateReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  rateLimit: {
+    /**
+     * **Note:** Accessing this endpoint does not count against your REST API rate limit.
+     *
+     * **Note:** The `rate` object is deprecated. If you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["rateLimit"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["rateLimit"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  reactions: {
+    /**
+     * Create a reaction to a [commit comment](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#comments). A response with an HTTP `200` status means that you already added the reaction type to this commit comment.
+     */
+    createForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue](https://docs.github.com/enterprise-server@2.20/rest/reference/issues/). A response with an HTTP `200` status means that you already added the reaction type to this issue.
+     */
+    createForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue comment](https://docs.github.com/enterprise-server@2.20/rest/reference/issues#comments). A response with an HTTP `200` status means that you already added the reaction type to this issue comment.
+     */
+    createForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#comments). A response with an HTTP `200` status means that you already added the reaction type to this pull request review comment.
+     */
+    createForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion.
+     */
+    createForTeamDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion comment.
+     */
+    createForTeamDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), when deleting a [team discussion](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#discussions) or [team discussion comment](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#discussion-comments).
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["reactions"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [commit comment](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#comments).
+     */
+    listForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue](https://docs.github.com/enterprise-server@2.20/rest/reference/issues).
+     */
+    listForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue comment](https://docs.github.com/enterprise-server@2.20/rest/reference/issues#comments).
+     */
+    listForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [pull request review comment](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#review-comments).
+     */
+    listForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#discussions). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listForTeamDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion comment](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#discussion-comments). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listForTeamDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["acceptInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["acceptInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified apps push access for this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * For more information the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * The invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#invitations).
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    addStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified teams push access for this branch. You can also give push access to child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified people push access for this branch.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    checkCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["checkCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["checkCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated**: Use `repos.compareCommitsWithBasehead()` (`GET /repos/{owner}/{repo}/compare/{basehead}`) instead. Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * To process a response with a large number of commits, you can use (`per_page` or `page`) to paginate the results. When using paging, the list of changed files is only returned with page 1, but includes all changed files for the entire comparison. For more information on working with pagination, see "[Traversing with pagination](/rest/guides/traversing-with-pagination)."
+     *
+     * When calling this API without any paging parameters (`per_page` or `page`), the returned list is limited to 250 commits and the last commit in the list is the most recent of the entire comparison. When a paging parameter is specified, the first commit in the returned list of each page is the earliest.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommits"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommits"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `basehead` param is comprised of two parts: `base` and `head`. Both must be branch names in `repo`. To compare branches across other repositories in the same network as `repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * The response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [List commits](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#list-commits) to enumerate all commits in the range.
+     *
+     * For comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long
+     * to generate. You can typically resolve this error by using a smaller commit range.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommitsWithBasehead: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a comment for a commit using its `:commit_sha`.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to require signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    createCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access in a repository can create commit statuses for a given SHA.
+     *
+     * Note: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.
+     */
+    createCommitStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can create a read-only deploy key.
+     */
+    createDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deployments offer a few configurable parameters with certain defaults.
+     *
+     * The `ref` parameter can be any named branch, tag, or SHA. At GitHub Enterprise Server we often deploy branches and verify them
+     * before we merge a pull request.
+     *
+     * The `environment` parameter allows deployments to be issued to different runtime environments. Teams often have
+     * multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This parameter
+     * makes it easier to track which environments have requested deployments. The default environment is `production`.
+     *
+     * The `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If
+     * the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds,
+     * the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will
+     * return a failure response.
+     *
+     * By default, [commit statuses](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#statuses) for every submitted context must be in a `success`
+     * state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to
+     * specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do
+     * not require any contexts or create any commit statuses, the deployment will always succeed.
+     *
+     * The `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text
+     * field that will be passed on when a deployment event is dispatched.
+     *
+     * The `task` parameter is used by the deployment system to allow different execution paths. In the web world this might
+     * be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an
+     * application with debugging enabled.
+     *
+     * Users with `repo` or `repo_deployment` scopes can create a deployment for a given ref.
+     *
+     * #### Merged branch response
+     * You will see this response when GitHub automatically merges the base branch into the topic branch instead of creating
+     * a deployment. This auto-merge happens when:
+     * *   Auto-merge option is enabled in the repository
+     * *   Topic branch does not include the latest changes on the base branch, which is `master` in the response example
+     * *   There are no merge conflicts
+     *
+     * If there are no new commits in the base branch, a new request to create a deployment should give a successful
+     * response.
+     *
+     * #### Merge conflict response
+     * This error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't
+     * be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.
+     *
+     * #### Failed commit status checks
+     * This error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success`
+     * status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.
+     */
+    createDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with `push` access can create deployment statuses for a given deployment.
+     *
+     * GitHub Apps require `read & write` access to "Deployments" and `read-only` access to "Repo contents" (for private repos). OAuth Apps require the `repo_deployment` scope.
+     */
+    createDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository.
+     */
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a fork for the authenticated user.
+     *
+     * **Note**: Forking a Repository happens asynchronously. You may have to wait a short period of time before you can access the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub Enterprise Server Support](https://support.github.com/contact) or [GitHub Enterprise Server Premium Support](https://premium.githubsupport.com).
+     */
+    createFork: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createFork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createFork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository in the specified organization. The authenticated user must be a member of the organization.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createInOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new file or replaces an existing file in a repository.
+     */
+    createOrUpdateFileContents: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Configures a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages)."
+     */
+    createPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can create a release.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository using a repository template. Use the `template_owner` and `template_repo` route parameters to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the [Get a repository](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#get-a-repository) endpoint and check that the `is_template` key is `true`.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createUsingTemplate: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createUsingTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createUsingTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can
+     * share the same `config` as long as those webhooks do not have any `events` that overlap.
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    declineInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["declineInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["declineInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+     *
+     * If an organization owner has configured the organization to prevent members from deleting organization-owned
+     * repositories, you will get a `403 Forbidden` response.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Disables the ability to restrict who can push to this branch.
+     */
+    deleteAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    deleteAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deleteBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to disable required signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    deleteCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
+     */
+    deleteDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a file in a repository.
+     *
+     * You can provide an additional `committer` parameter, which is an object containing information about the committer. Or, you can provide an `author` parameter, which is an object containing information about the author.
+     *
+     * The `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.
+     *
+     * You must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.
+     */
+    deleteFile: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteFile"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteFile"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deletePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can delete a release.
+     */
+    deleteRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a tar archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadTarballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a zip archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadZipballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you pass the `scarlet-witch-preview` media type, requests to get a repository will also return the repository's code of conduct if it can be detected from the repository's code of conduct file.
+     *
+     * The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["repos"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["repos"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists who has access to this protected branch.
+     *
+     * **Note**: Users, apps, and teams `restrictions` are only available for organization-owned repositories.
+     */
+    getAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAllStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllTopics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getAllTopics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the GitHub Apps that have push access to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     */
+    getAppsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+     */
+    getCodeFrequencyStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks the repository permission of a collaborator. The possible repository permissions are `admin`, `write`, `read`, and `none`.
+     */
+    getCollaboratorPermissionLevel: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
+     *
+     * The most recent status for each context is returned, up to 100. This field [paginates](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination) if there are over 100 contexts.
+     *
+     * Additionally, a combined `state` is returned. The `state` is one of:
+     *
+     * *   **failure** if any of the contexts report as `error` or `failure`
+     * *   **pending** if there are no statuses or a context is `pending`
+     * *   **success** if the latest status for all contexts is `success`
+     */
+    getCombinedStatusForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the contents of a single commit reference. You must have `read` access for the repository to use this endpoint.
+     *
+     * **Note:** If there are more than 300 files in the commit diff, the response will include pagination link headers for the remaining files, up to a limit of 3000 files. Each page contains the static commit information, and the only changes are to the file listing.
+     *
+     * You can pass the appropriate [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to  fetch `diff` and `patch` formats. Diffs with binary data will have no `patch` property.
+     *
+     * To return only the SHA-1 hash of the commit reference, you can provide the `sha` custom [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) in the `Accept` header. You can use this endpoint to check if a remote reference's SHA-1 hash is the same as your local reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.
+     */
+    getCommitActivityStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to check whether a branch requires signed commits. An enabled status of `true` indicates you must sign commits on this branch. For more information, see [Signing commits with GPG](https://help.github.com/articles/signing-commits-with-gpg) in GitHub Help.
+     *
+     * **Note**: You must enable branch protection to require signed commits.
+     */
+    getCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the contents of a file or directory in a repository. Specify the file path or directory in `:path`. If you omit
+     * `:path`, you will receive the contents of the repository's root directory. See the description below regarding what the API response includes for directories.
+     *
+     * Files and symlinks support [a custom media type](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#custom-media-types) for
+     * retrieving the raw content or rendered HTML (when supported). All content types support [a custom media
+     * type](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#custom-media-types) to ensure the content is returned in a consistent
+     * object format.
+     *
+     * **Note**:
+     * *   To get a repository's contents recursively, you can [recursively get the tree](https://docs.github.com/enterprise-server@2.20/rest/reference/git#trees).
+     * *   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees
+     * API](https://docs.github.com/enterprise-server@2.20/rest/reference/git#get-a-tree).
+     * *   This API supports files up to 1 megabyte in size.
+     *
+     * #### If the content is a directory
+     * The response will be an array of objects, one object for each item in the directory.
+     * When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value
+     * _should_ be "submodule". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW).
+     * In the next major version of the API, the type will be returned as "submodule".
+     *
+     * #### If the content is a symlink
+     * If the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the
+     * API responds with the content of the file (in the format shown in the example. Otherwise, the API responds with an object
+     * describing the symlink itself.
+     *
+     * #### If the content is a submodule
+     * The `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific
+     * commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out
+     * the submodule at that specific commit.
+     *
+     * If the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links["git"]`) and the
+     * github.com URLs (`html_url` and `_links["html"]`) will have null values.
+     */
+    getContent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getContent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the `total` number of commits authored by the contributor. In addition, the response includes a Weekly Hash (`weeks` array) with the following information:
+     *
+     * *   `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+     * *   `a` - Number of additions
+     * *   `d` - Number of deletions
+     * *   `c` - Number of commits
+     */
+    getContributorsStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContributorsStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getContributorsStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployKey"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployKey"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view a deployment status for a deployment:
+     */
+    getDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLatestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View the latest published full release for the repository.
+     *
+     * The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
+     */
+    getLatestRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestRelease"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestRelease"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPagesBuild"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPagesBuild"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.
+     *
+     * The array order is oldest week (index 0) to most recent week.
+     */
+    getParticipationStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getParticipationStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getParticipationStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getPullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Each array contains the day number, hour number, and number of commits:
+     *
+     * *   `0-6`: Sunday - Saturday
+     * *   `0-23`: Hour of day
+     * *   Number of commits
+     *
+     * For example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+     */
+    getPunchCardStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPunchCardStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPunchCardStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the preferred README for a repository.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadme: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadme"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getReadme"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the README from a repository directory.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadmeInDirectory: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#hypermedia).
+     */
+    getRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.
+     */
+    getReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a published release with the specified tag.
+     */
+    getReleaseByTag: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseByTag"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getStatusChecksProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the teams who have push access to this branch. The list includes child teams.
+     */
+    getTeamsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the people who have push access to this branch.
+     */
+    getUsersWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in a repository. To get only the webhook `config` properties, see "[Get a webhook configuration for a repository](/rest/reference/repos#get-a-webhook-configuration-for-a-repository)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listBranches: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranches"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listBranches"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Returns all branches where the given commit SHA is the HEAD, or latest commit for the branch.
+     */
+    listBranchesForHeadCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use the `:commit_sha` to specify the commit that will have its comments listed.
+     */
+    listCommentsForCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Commit Comments use [these custom media types](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#custom-media-types). You can read more about the use of media types in the API [here](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/).
+     *
+     * Comments are ordered by ascending ID.
+     */
+    listCommitCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.
+     *
+     * This resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.
+     */
+    listCommitStatusesForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
+     *
+     * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
+     */
+    listContributors: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listContributors"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listContributors"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listDeployKeys: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view deployment statuses for a deployment:
+     */
+    listDeploymentStatuses: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Simple filtering of deployments is available via query parameters:
+     */
+    listDeployments: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories for the specified organization.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public repositories for the specified user. Note: For GitHub AE, this endpoint will list internal repositories for the specified user.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.
+     */
+    listInvitations: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user, this endpoint will list all currently open repository invitations for that user.
+     */
+    listInvitationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.
+     */
+    listLanguages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listLanguages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listLanguages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPagesBuilds: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPagesBuilds"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPagesBuilds"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all public repositories in the order that they were created.
+     *
+     * Note:
+     * - For GitHub Enterprise Server, this endpoint will only list repositories available to all users on the enterprise.
+     * - Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of repositories.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, additionally returns open pull requests associated with the commit. The results may include open and closed pull requests. Additional preview headers may be required to see certain details for associated pull requests, such as whether a pull request is in a draft state. For more information about previews that might affect this endpoint, see the [List pull requests](https://docs.github.com/enterprise-server@2.20/rest/reference/pulls#list-pull-requests) endpoint.
+     */
+    listPullRequestsAssociatedWithCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReleaseAssets: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleaseAssets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#list-repository-tags).
+     *
+     * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+     */
+    listReleases: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleases"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listReleases"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTags: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTags"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTags"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTeams: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTeams"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTeams"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.20/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of an app to push to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a team to push to this branch. You can also remove push access for child teams.
+     *
+     * | Type    | Description                                                                                                                                         |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a user to push to this branch.
+     *
+     * | Type    | Description                                                                                                                                   |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames of the people who should no longer have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    replaceAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["replaceAllTopics"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["replaceAllTopics"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.
+     *
+     * Build requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.
+     */
+    requestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["requestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["requestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    setAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of apps that have push access to this branch. This removes all apps that previously had push access and grants push access to the new list of apps. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    setStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. Team restrictions include child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.
+     *
+     * **Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`
+     */
+    testPushWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["testPushWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["testPushWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * A transfer request will need to be accepted by the new owner when transferring a personal repository to another user. The response will contain the original `owner`, and the transfer will continue asynchronously. For more details on the requirements to transfer personal and organization-owned repositories, see [about repository transfers](https://help.github.com/articles/about-repository-transfers/).
+     */
+    transfer: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["transfer"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["transfer"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: To edit a repository's topics, use the [Replace all repository topics](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#replace-all-repository-topics) endpoint.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Protecting a branch requires admin or owner permissions to the repository.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     *
+     * **Note**: The list of users, apps, and teams in total is limited to 100 items.
+     */
+    updateBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates information for a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages).
+     */
+    updateInformationAboutPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     */
+    updatePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release.
+     */
+    updateRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release asset.
+     */
+    updateReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    updateStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in a repository. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for a repository](/rest/reference/repos#update-a-webhook-configuration-for-a-repository)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint makes use of [a Hypermedia relation](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#hypermedia) to determine which URL to access. The endpoint you call to upload release assets is specific to your release. Use the `upload_url` returned in
+     * the response of the [Create a release endpoint](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#create-a-release) to upload a release asset.
+     *
+     * You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.
+     *
+     * Most libraries will set the required `Content-Length` header automatically. Use the required `Content-Type` header to provide the media type of the asset. For a list of media types, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). For example:
+     *
+     * `application/zip`
+     *
+     * GitHub Enterprise Server expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body. Everything else about the endpoint is the same as the rest of the API. For example,
+     * you'll still need to pass your authentication to be able to upload an asset.
+     *
+     * When an upstream failure occurs, you will receive a `502 Bad Gateway` status. This may leave an empty asset with a state of `starter`. It can be safely deleted.
+     *
+     * **Notes:**
+     * *   GitHub Enterprise Server renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "[List assets for a release](https://docs.github.com/enterprise-server@2.20/rest/reference/repos#list-assets-for-a-release)"
+     * endpoint lists the renamed filenames. For more information and help, contact [GitHub Enterprise Server Support](https://support.github.com/contact).
+     * *   If you upload an asset with the same filename as another uploaded asset, you'll receive an error and must delete the old file before you can re-upload the new asset.
+     */
+    uploadReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  search: {
+    /**
+     * Searches for query terms inside of a file. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for code, you can get text match metadata for the file **content** and file **path** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery) repository, your query would look something like this:
+     *
+     * `q=addClass+in:file+language:js+repo:jquery/jquery`
+     *
+     * This query searches for the keyword `addClass` within a file's contents. The query limits the search to files where the language is JavaScript in the `jquery/jquery` repository.
+     *
+     * #### Considerations for code search
+     *
+     * Due to the complexity of searching code, there are a few restrictions on how searches are performed:
+     *
+     * *   Only the _default branch_ is considered. In most cases, this will be the `master` branch.
+     * *   Only files smaller than 384 KB are searchable.
+     * *   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing
+     * language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.
+     */
+    code: {
+      (
+        params?: RestEndpointMethodTypes["search"]["code"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["code"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find commits via various criteria on the default branch (usually `master`). This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for commits, you can get text match metadata for the **message** field when you provide the `text-match` media type. For more details about how to receive highlighted search results, see [Text match
+     * metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:
+     *
+     * `q=repo:octocat/Spoon-Knife+css`
+     */
+    commits: {
+      (
+        params?: RestEndpointMethodTypes["search"]["commits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["commits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find issues by state and keyword. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields when you pass the `text-match` media type. For more details about how to receive highlighted
+     * search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.
+     *
+     * `q=windows+label:bug+language:python+state:open&sort=created&order=asc`
+     *
+     * This query searches for the keyword `windows`, within any open issue that is labeled as `bug`. The search runs across repositories whose primary language is Python. The results are sorted by creation date in ascending order, which means the oldest issues appear first in the search results.
+     *
+     * **Note:** For [user-to-server](https://docs.github.com/developers/apps/identifying-and-authorizing-users-for-github-apps#user-to-server-requests) GitHub App requests, you can't retrieve a combination of issues and pull requests in a single query. Requests that don't include the `is:issue` or `is:pull-request` qualifier will receive an HTTP `422 Unprocessable Entity` response. To get results for both issues and pull requests, you must send separate queries for issues and pull requests. For more information about the `is` qualifier, see "[Searching only issues or pull requests](https://docs.github.com/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-only-issues-or-pull-requests)."
+     */
+    issuesAndPullRequests: {
+      (
+        params?: RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find labels in a repository with names or descriptions that match search keywords. Returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for labels, you can get text match metadata for the label **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find labels in the `linguist` repository that match `bug`, `defect`, or `enhancement`. Your query might look like this:
+     *
+     * `q=bug+defect+enhancement&repository_id=64778136`
+     *
+     * The labels that best match the query appear first in the search results.
+     */
+    labels: {
+      (
+        params?: RestEndpointMethodTypes["search"]["labels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["labels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find repositories via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for repositories, you can get text match metadata for the **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for popular Tetris repositories written in assembly code, your query might look like this:
+     *
+     * `q=tetris+language:assembly&sort=stars&order=desc`
+     *
+     * This query searches for repositories with the word `tetris` in the name, the description, or the README. The results are limited to repositories where the primary language is assembly. The results are sorted by stars in descending order, so that the most popular repositories appear first in the search results.
+     *
+     * When you include the `mercy` preview header, you can also search for multiple topics by adding more `topic:` instances. For example, your query might look like this:
+     *
+     * `q=topic:ruby+topic:rails`
+     */
+    repos: {
+      (
+        params?: RestEndpointMethodTypes["search"]["repos"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["repos"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find topics via various criteria. Results are sorted by best match. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination). See "[Searching topics](https://help.github.com/articles/searching-topics/)" for a detailed list of qualifiers.
+     *
+     * When searching for topics, you can get text match metadata for the topic's **short\_description**, **description**, **name**, or **display\_name** field when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for topics related to Ruby that are featured on https://github.com/topics. Your query might look like this:
+     *
+     * `q=ruby+is:featured`
+     *
+     * This query searches for topics with the keyword `ruby` and limits the results to find only topics that are featured. The topics that are the best match for the query appear first in the search results.
+     */
+    topics: {
+      (
+        params?: RestEndpointMethodTypes["search"]["topics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["topics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find users via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields when you pass the `text-match` media type. For more details about highlighting search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata). For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.20/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you're looking for a list of popular users, you might try this query:
+     *
+     * `q=tom+repos:%3E42+followers:%3E1000`
+     *
+     * This query searches for users with the name `tom`. The results are restricted to users with more than 42 repositories and over 1,000 followers.
+     */
+    users: {
+      (
+        params?: RestEndpointMethodTypes["search"]["users"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["users"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  teams: {
+    /**
+     * If the user is already a member of the team's organization, this endpoint will add the user to the team. To add a membership between an organization member and a team, the authenticated user must be an organization owner or a team maintainer.
+     *
+     * If the user is unaffiliated with the team's organization, this endpoint will send an invitation to the user via email. This newly-created membership will be in the "pending" state until the user accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team. To add a membership between an unaffiliated user and a team, the authenticated user must be an organization owner.
+     *
+     * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
+     */
+    addOrUpdateMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
+     */
+    addOrUpdateProjectPermissions: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    addOrUpdateRepoPermissions: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
+     */
+    checkPermissionsForProject: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForProject"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForProject"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: Repositories inherited through a parent team will also be checked.
+     *
+     * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://docs.github.com/enterprise-server@2.20/rest/overview/media-types/) via the `Accept` header:
+     */
+    checkPermissionsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams. Organization owners can limit team creation to organization owners. For more information, see "[Setting team creation permissions](https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization)."
+     *
+     * When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of `maintainers`. For more information, see "[About teams](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" for details.
+     */
+    createDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" for details.
+     */
+    createDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To delete a team, the authenticated user must be an organization owner or team maintainer.
+     *
+     * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    get: {
+      (params?: RestEndpointMethodTypes["teams"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["teams"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a team using the team's `slug`. GitHub Enterprise Server generates the `slug` from the team `name`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}`.
+     */
+    getByName: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getByName"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["getByName"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussion"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["getDiscussion"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To get a user's membership with a team, the team must be visible to the authenticated user.
+     *
+     * **Note:** The `role` for organization owners returns as `maintainer`. For more information about `maintainer` roles, see [Create a team](https://docs.github.com/enterprise-server@2.20/rest/reference/teams#create-a-team).
+     */
+    getMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all teams in an organization that are visible to the authenticated user.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listChild: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listChild"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["listChild"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listDiscussionComments: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionComments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionComments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listDiscussions: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/).
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To list members in a team, the team must be visible to the authenticated user.
+     */
+    listMembers: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listMembers"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["listMembers"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organization projects for a team. If you are an [authenticated](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#authentication) site administrator for your Enterprise instance, you will be able to list all projects for the team.
+     */
+    listProjects: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listProjects"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["listProjects"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are an [authenticated](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#authentication) site administrator for your Enterprise instance, you will be able to list all repositories for the team.
+     */
+    listRepos: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listRepos"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["listRepos"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
+     */
+    removeMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. **Note:** This endpoint removes the project from the team, but does not delete it.
+     */
+    removeProject: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeProject"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["removeProject"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. NOTE: This does not delete the repository, it just removes it from the team.
+     */
+    removeRepo: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["removeRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
+     *
+     * **Note:** With nested teams, the `privacy` for parent teams cannot be `secret`.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    updateDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    updateDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  users: {
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    addEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPersonIsFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a GPG key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    deleteEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GPG key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deletePublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    follow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["follow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["follow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is authenticated through basic authentication or OAuth with the `user` scope, then the response lists public and private profile information.
+     *
+     * If the authenticated user is authenticated through OAuth without the `user` scope, then the response lists only public profile information.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides publicly available information about someone with a GitHub account.
+     *
+     * GitHub Apps with the `Plan` user permission can use this endpoint to retrieve information about a user's GitHub Enterprise Server plan. The GitHub App must be authenticated as a user. See "[Identifying and authorizing users for GitHub Apps](https://docs.github.com/enterprise-server@2.20/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)" for details about authentication. For an example response, see 'Response with GitHub Enterprise Server plan information' below"
+     *
+     * The `email` key in the following response is the publicly visible email address from your GitHub Enterprise Server [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub Enterprise Server. For more information, see [Authentication](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#authentication).
+     *
+     * The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "[Emails API](https://docs.github.com/enterprise-server@2.20/rest/reference/users#emails)".
+     */
+    getByUsername: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getByUsername"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["getByUsername"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides hovercard information when authenticated through basic auth or OAuth with the `repo` scope. You can find out more about someone in relation to their pull requests, issues, repositories, and organizations.
+     *
+     * The `subject_type` and `subject_id` parameters provide context for the person's hovercard, which returns more information than without the parameters. For example, if you wanted to find out more about `octocat` who owns the `Spoon-Knife` repository via cURL, it would look like this:
+     *
+     * ```shell
+     *  curl -u username:token
+     *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
+     * ```
+     */
+    getContextForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getContextForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getContextForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all users, in the order that they signed up on GitHub Enterprise Server. This list includes personal user accounts and organization accounts.
+     *
+     * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.20/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of users.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["users"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.
+     */
+    listEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the authenticated user follows.
+     */
+    listFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the authenticated user.
+     */
+    listFollowersForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the specified user.
+     */
+    listFollowersForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the specified user follows.
+     */
+    listFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listGpgKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the GPG keys for a user. This information is accessible by anyone.
+     */
+    listGpgKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists your publicly visible email address, which you can set with the [Set primary email visibility for the authenticated user](https://docs.github.com/enterprise-server@2.20/rest/reference/users#set-primary-email-visibility-for-the-authenticated-user) endpoint. This endpoint is accessible with the `user:email` scope.
+     */
+    listPublicEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the _verified_ public SSH keys for a user. This is accessible by anyone.
+     */
+    listPublicKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@2.20/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listPublicSshKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    unfollow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["unfollow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["unfollow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.
+     */
+    updateAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["updateAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["updateAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+};

--- a/src/generated/ghe-220-parameters-and-response-types.ts
+++ b/src/generated/ghe-220-parameters-and-response-types.ts
@@ -1,0 +1,4088 @@
+import { Endpoints, RequestParameters } from "@octokit/types";
+
+export type RestEndpointMethodTypes = {
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred/{owner}/{repo}"]["response"];
+    };
+    deleteRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    deleteThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    getFeeds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /feeds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /feeds"]["response"];
+    };
+    getRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    getThread: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}"]["response"];
+    };
+    getThreadSubscriptionForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    listEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events"]["response"];
+    };
+    listNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications"]["response"];
+    };
+    listOrgEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/orgs/{org}"]["response"];
+    };
+    listPublicEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /events"]["response"];
+    };
+    listPublicEventsForRepoNetwork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /networks/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /networks/{owner}/{repo}/events"]["response"];
+    };
+    listPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/public"]["response"];
+    };
+    listPublicOrgEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/events"]["response"];
+    };
+    listReceivedEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events"]["response"];
+    };
+    listReceivedPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events/public"]["response"];
+    };
+    listRepoEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/events"]["response"];
+    };
+    listRepoNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    listReposStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred"]["response"];
+    };
+    listReposStarredByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/starred"]["response"];
+    };
+    listReposWatchedByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/subscriptions"]["response"];
+    };
+    listStargazersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stargazers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stargazers"]["response"];
+    };
+    listWatchedReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/subscriptions"]["response"];
+    };
+    listWatchersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscribers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscribers"]["response"];
+    };
+    markNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications"]["response"];
+    };
+    markRepoNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    markThreadAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /notifications/threads/{thread_id}"]["response"];
+    };
+    setRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    setThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    starRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/starred/{owner}/{repo}"]["response"];
+    };
+    unstarRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/starred/{owner}/{repo}"]["response"];
+    };
+  };
+  apps: {
+    addRepoToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    checkToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /applications/{client_id}/token"]["response"];
+    };
+    createContentAttachment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createContentAttachmentForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createFromManifest: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app-manifests/{code}/conversions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app-manifests/{code}/conversions"]["response"];
+    };
+    createInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app/installations/{installation_id}/access_tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app/installations/{installation_id}/access_tokens"]["response"];
+    };
+    deleteAuthorization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/grant"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/grant"]["response"];
+    };
+    deleteInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /app/installations/{installation_id}"]["response"];
+    };
+    deleteToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/token"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app"]["response"];
+    };
+    getBySlug: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /apps/{app_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /apps/{app_slug}"]["response"];
+    };
+    getInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations/{installation_id}"]["response"];
+    };
+    getOrgInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installation"]["response"];
+    };
+    getRepoInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/installation"]["response"];
+    };
+    getUserInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/installation"]["response"];
+    };
+    listInstallationReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations/{installation_id}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations/{installation_id}/repositories"]["response"];
+    };
+    listInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations"]["response"];
+    };
+    listInstallationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations"]["response"];
+    };
+    listReposAccessibleToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /installation/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /installation/repositories"]["response"];
+    };
+    removeRepoFromInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    resetToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /applications/{client_id}/token"]["response"];
+    };
+    revokeInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /installation/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /installation/token"]["response"];
+    };
+  };
+  checks: {
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-runs"]["response"];
+    };
+    createSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+    getSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["response"];
+    };
+    listAnnotations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["response"];
+    };
+    listForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["response"];
+    };
+    listForSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["response"];
+    };
+    listSuitesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["response"];
+    };
+    rerequestSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["response"];
+    };
+    setSuitesPreferences: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct"]["response"];
+    };
+    getConductCode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct/{key}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct/{key}"]["response"];
+    };
+  };
+  emojis: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /emojis"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /emojis"]["response"];
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/settings/authorized-keys"]["response"];
+    };
+    createEnterpriseServerLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/start"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/start"]["response"];
+    };
+    createGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks"]["response"];
+    };
+    createImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users/{username}/authorizations"]["response"];
+    };
+    createOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/organizations"]["response"];
+    };
+    createPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments"]["response"];
+    };
+    createPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-hooks"]["response"];
+    };
+    createUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users"]["response"];
+    };
+    deleteGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/hooks/{hook_id}"]["response"];
+    };
+    deleteImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}/authorizations"]["response"];
+    };
+    deletePersonalAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/tokens/{token_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/tokens/{token_id}"]["response"];
+    };
+    deletePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    deletePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    deletePublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/keys/{key_ids}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/keys/{key_ids}"]["response"];
+    };
+    deleteUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}"]["response"];
+    };
+    demoteSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/site_admin"]["response"];
+    };
+    enableOrDisableMaintenanceMode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/maintenance"]["response"];
+    };
+    getAllAuthorizedSshKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings/authorized-keys"]["response"];
+    };
+    getAllStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/gists"]["response"];
+    };
+    getCommentStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/comments"]["response"];
+    };
+    getConfigurationStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/configcheck"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/configcheck"]["response"];
+    };
+    getDownloadStatusForPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["response"];
+    };
+    getGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks/{hook_id}"]["response"];
+    };
+    getHooksStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/hooks"]["response"];
+    };
+    getIssueStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/issues"]["response"];
+    };
+    getLicenseInformation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/settings/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/settings/license"]["response"];
+    };
+    getMaintenanceStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/maintenance"]["response"];
+    };
+    getMilestoneStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/milestones"]["response"];
+    };
+    getOrgStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/orgs"]["response"];
+    };
+    getPagesStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pages"]["response"];
+    };
+    getPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    getPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPullRequestStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pulls"]["response"];
+    };
+    getRepoStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/repos"]["response"];
+    };
+    getSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings"]["response"];
+    };
+    getUserStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/users"]["response"];
+    };
+    listGlobalWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks"]["response"];
+    };
+    listPersonalAccessTokens: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/tokens"]["response"];
+    };
+    listPreReceiveEnvironments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments"]["response"];
+    };
+    listPreReceiveHooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["response"];
+    };
+    listPublicKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/keys"]["response"];
+    };
+    pingGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks/{hook_id}/pings"]["response"];
+    };
+    promoteUserToBeSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/site_admin"]["response"];
+    };
+    removeAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /setup/api/settings/authorized-keys"]["response"];
+    };
+    removePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    removePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    setSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /setup/api/settings"]["response"];
+    };
+    startConfigurationProcess: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/configure"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/configure"]["response"];
+    };
+    startPreReceiveEnvironmentDownload: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["response"];
+    };
+    suspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/suspended"]["response"];
+    };
+    syncLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["response"];
+    };
+    syncLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/users/{username}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/users/{username}/sync"]["response"];
+    };
+    unsuspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/suspended"]["response"];
+    };
+    updateGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/hooks/{hook_id}"]["response"];
+    };
+    updateLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["response"];
+    };
+    updateLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["response"];
+    };
+    updateOrgName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/organizations/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/organizations/{org}"]["response"];
+    };
+    updatePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    updatePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updateUsernameForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/users/{username}"]["response"];
+    };
+    upgradeLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/upgrade"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/upgrade"]["response"];
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/star"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/comments"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    fork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/forks"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    getRevision: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/{sha}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/commits"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gists"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/forks"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/public"]["response"];
+    };
+    listStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/starred"]["response"];
+    };
+    star: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /gists/{gist_id}/star"]["response"];
+    };
+    unstar: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/star"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+  };
+  git: {
+    createBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["response"];
+    };
+    createCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/commits"]["response"];
+    };
+    createRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/refs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/refs"]["response"];
+    };
+    createTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/tags"]["response"];
+    };
+    createTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/trees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/trees"]["response"];
+    };
+    deleteRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+    getBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["response"];
+    };
+    getRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["response"];
+    };
+    getTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["response"];
+    };
+    getTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["response"];
+    };
+    listMatchingRefs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["response"];
+    };
+    updateRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+  };
+  gitignore: {
+    getAllTemplates: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates"]["response"];
+    };
+    getTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates/{name}"]["response"];
+    };
+  };
+  issues: {
+    addAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    addLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    checkUserCanBeAssigned: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    createLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/labels"]["response"];
+    };
+    createMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    deleteLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    deleteMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    getEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["response"];
+    };
+    getLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    getMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /issues"]["response"];
+    };
+    listAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    listCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["response"];
+    };
+    listEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["response"];
+    };
+    listEventsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events"]["response"];
+    };
+    listEventsForTimeline: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/issues"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/issues"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
+    };
+    listLabelsForMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["response"];
+    };
+    listLabelsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels"]["response"];
+    };
+    listLabelsOnIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    listMilestones: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    lock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    removeAllLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    removeAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    removeLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["response"];
+    };
+    setLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    unlock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    updateLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    updateMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+  };
+  licenses: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses/{license}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses/{license}"]["response"];
+    };
+    getAllCommonlyUsed: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses"]["response"];
+    };
+    getForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/license"]["response"];
+    };
+  };
+  markdown: {
+    render: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown"]["response"];
+    };
+    renderRaw: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown/raw"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown/raw"]["response"];
+    };
+  };
+  meta: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /meta"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /meta"]["response"];
+    };
+    getOctocat: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /octocat"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /octocat"]["response"];
+    };
+    getZen: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /zen"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /zen"]["response"];
+    };
+    root: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /"]["response"];
+    };
+  };
+  orgs: {
+    checkMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members/{username}"]["response"];
+    };
+    checkPublicMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members/{username}"]["response"];
+    };
+    convertMemberToOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}"]["response"];
+    };
+    getMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs/{org}"]["response"];
+    };
+    getMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/memberships/{username}"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /organizations"]["response"];
+    };
+    listAppInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installations"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/orgs"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/orgs"]["response"];
+    };
+    listMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members"]["response"];
+    };
+    listMembershipsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs"]["response"];
+    };
+    listOutsideCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/outside_collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/outside_collaborators"]["response"];
+    };
+    listPublicMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeMember: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/members/{username}"]["response"];
+    };
+    removeMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/memberships/{username}"]["response"];
+    };
+    removeOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    removePublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/public_members/{username}"]["response"];
+    };
+    setMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/memberships/{username}"]["response"];
+    };
+    setPublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/public_members/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}"]["response"];
+    };
+    updateMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/memberships/orgs/{org}"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+  };
+  projects: {
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    createCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/cards"]["response"];
+    };
+    createColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/{project_id}/columns"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/projects"]["response"];
+    };
+    createForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/projects"]["response"];
+    };
+    createForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/projects"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}"]["response"];
+    };
+    deleteCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/cards/{card_id}"]["response"];
+    };
+    deleteColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/{column_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}"]["response"];
+    };
+    getCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/cards/{card_id}"]["response"];
+    };
+    getColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}"]["response"];
+    };
+    getPermissionForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["response"];
+    };
+    listCards: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}/cards"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators"]["response"];
+    };
+    listColumns: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/columns"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/projects"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/projects"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/projects"]["response"];
+    };
+    moveCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/cards/{card_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/cards/{card_id}/moves"]["response"];
+    };
+    moveColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/moves"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/{project_id}"]["response"];
+    };
+    updateCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/cards/{card_id}"]["response"];
+    };
+    updateColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/{column_id}"]["response"];
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    createReplyForReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["response"];
+    };
+    createReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    createReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    deletePendingReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    deleteReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    dismissReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    getReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    getReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    listCommentsForReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["response"];
+    };
+    listFiles: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["response"];
+    };
+    listRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    listReviewComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    listReviewCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["response"];
+    };
+    listReviews: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    removeRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    requestReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    submitReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    updateBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["response"];
+    };
+    updateReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    updateReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+  };
+  rateLimit: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /rate_limit"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /rate_limit"]["response"];
+    };
+  };
+  reactions: {
+    createForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    createForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    createForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    createForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    createForTeamDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /teams/{team_id}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /teams/{team_id}/discussions/{discussion_number}/reactions"]["response"];
+    };
+    createForTeamDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /reactions/{reaction_id}"]["response"];
+    };
+    listForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    listForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    listForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    listForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    listForTeamDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/reactions"]["response"];
+    };
+    listForTeamDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    addAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    addStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    addTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    addUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    checkCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    compareCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["response"];
+    };
+    compareCommitsWithBasehead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["response"];
+    };
+    createCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    createCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    createCommitStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["response"];
+    };
+    createDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/keys"]["response"];
+    };
+    createDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    createDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/repos"]["response"];
+    };
+    createFork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/forks"]["response"];
+    };
+    createInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/repos"]["response"];
+    };
+    createOrUpdateFileContents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    createPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages"]["response"];
+    };
+    createRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/releases"]["response"];
+    };
+    createUsingTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    declineInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}"]["response"];
+    };
+    deleteAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    deleteAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    deleteBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    deleteCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    deleteCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    deleteDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    deleteFile: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    deleteInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    deletePagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pages"]["response"];
+    };
+    deletePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    deleteRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    deleteReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    downloadTarballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["response"];
+    };
+    downloadZipballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}"]["response"];
+    };
+    getAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    getAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    getAllStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    getAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/topics"]["response"];
+    };
+    getAppsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    getBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["response"];
+    };
+    getBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    getCodeFrequencyStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["response"];
+    };
+    getCollaboratorPermissionLevel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["response"];
+    };
+    getCombinedStatusForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["response"];
+    };
+    getCommitActivityStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["response"];
+    };
+    getCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    getCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    getContent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    getContributorsStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["response"];
+    };
+    getDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    getDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    getDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["response"];
+    };
+    getLatestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["response"];
+    };
+    getLatestRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["response"];
+    };
+    getPages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages"]["response"];
+    };
+    getPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["response"];
+    };
+    getParticipationStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["response"];
+    };
+    getPullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    getPunchCardStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["response"];
+    };
+    getReadme: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme"]["response"];
+    };
+    getReadmeInDirectory: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["response"];
+    };
+    getRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    getReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    getReleaseByTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["response"];
+    };
+    getStatusChecksProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    getTeamsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    getUsersWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    listBranches: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches"]["response"];
+    };
+    listBranchesForHeadCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators"]["response"];
+    };
+    listCommentsForCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    listCommitCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments"]["response"];
+    };
+    listCommitStatusesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits"]["response"];
+    };
+    listContributors: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contributors"]["response"];
+    };
+    listDeployKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys"]["response"];
+    };
+    listDeploymentStatuses: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    listDeployments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repos"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/repos"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/repos"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/forks"]["response"];
+    };
+    listInvitations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/invitations"]["response"];
+    };
+    listInvitationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repository_invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repository_invitations"]["response"];
+    };
+    listLanguages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/languages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/languages"]["response"];
+    };
+    listPagesBuilds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repositories"]["response"];
+    };
+    listPullRequestsAssociatedWithCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["response"];
+    };
+    listReleaseAssets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["response"];
+    };
+    listReleases: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases"]["response"];
+    };
+    listTags: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tags"]["response"];
+    };
+    listTeams: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/teams"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/merges"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/merges"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    removeStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    removeStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    removeTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    removeUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    replaceAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/topics"]["response"];
+    };
+    requestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    setAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    setAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    setStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    setTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    setUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    testPushWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["response"];
+    };
+    transfer: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/transfer"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/transfer"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}"]["response"];
+    };
+    updateBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    updateCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    updateInformationAboutPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pages"]["response"];
+    };
+    updateInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    updatePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    updateRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    updateReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    updateStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    uploadReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["response"];
+    };
+  };
+  search: {
+    code: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/code"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/code"]["response"];
+    };
+    commits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/commits"]["response"];
+    };
+    issuesAndPullRequests: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/issues"]["response"];
+    };
+    labels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/labels"]["response"];
+    };
+    repos: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/repositories"]["response"];
+    };
+    topics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/topics"]["response"];
+    };
+    users: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/users"]["response"];
+    };
+  };
+  teams: {
+    addOrUpdateMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /teams/{team_id}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /teams/{team_id}/memberships/{username}"]["response"];
+    };
+    addOrUpdateProjectPermissions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /teams/{team_id}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /teams/{team_id}/projects/{project_id}"]["response"];
+    };
+    addOrUpdateRepoPermissions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /teams/{team_id}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /teams/{team_id}/repos/{owner}/{repo}"]["response"];
+    };
+    checkPermissionsForProject: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/projects/{project_id}"]["response"];
+    };
+    checkPermissionsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/repos/{owner}/{repo}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams"]["response"];
+    };
+    createDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /teams/{team_id}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /teams/{team_id}/discussions"]["response"];
+    };
+    createDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /teams/{team_id}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /teams/{team_id}/discussions/{discussion_number}/comments"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /teams/{team_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /teams/{team_id}"]["response"];
+    };
+    deleteDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /teams/{team_id}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /teams/{team_id}/discussions/{discussion_number}"]["response"];
+    };
+    deleteDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}"]["response"];
+    };
+    getByName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/discussions/{discussion_number}"]["response"];
+    };
+    getDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    getMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/memberships/{username}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams"]["response"];
+    };
+    listChild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/teams"]["response"];
+    };
+    listDiscussionComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/discussions/{discussion_number}/comments"]["response"];
+    };
+    listDiscussions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/discussions"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/teams"]["response"];
+    };
+    listMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/members"]["response"];
+    };
+    listProjects: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/projects"]["response"];
+    };
+    listRepos: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /teams/{team_id}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /teams/{team_id}/repos"]["response"];
+    };
+    removeMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /teams/{team_id}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /teams/{team_id}/memberships/{username}"]["response"];
+    };
+    removeProject: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /teams/{team_id}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /teams/{team_id}/projects/{project_id}"]["response"];
+    };
+    removeRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /teams/{team_id}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /teams/{team_id}/repos/{owner}/{repo}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /teams/{team_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /teams/{team_id}"]["response"];
+    };
+    updateDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /teams/{team_id}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /teams/{team_id}/discussions/{discussion_number}"]["response"];
+    };
+    updateDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+  };
+  users: {
+    addEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/emails"]["response"];
+    };
+    checkFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following/{target_user}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following/{target_user}"]["response"];
+    };
+    checkPersonIsFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following/{username}"]["response"];
+    };
+    createGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/gpg_keys"]["response"];
+    };
+    createPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/keys"]["response"];
+    };
+    deleteEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/emails"]["response"];
+    };
+    deleteGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    deletePublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/keys/{key_id}"]["response"];
+    };
+    follow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/following/{username}"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user"]["response"];
+    };
+    getByUsername: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}"]["response"];
+    };
+    getContextForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/hovercard"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/hovercard"]["response"];
+    };
+    getGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    getPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys/{key_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users"]["response"];
+    };
+    listEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/emails"]["response"];
+    };
+    listFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following"]["response"];
+    };
+    listFollowersForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/followers"]["response"];
+    };
+    listFollowersForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/followers"]["response"];
+    };
+    listFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following"]["response"];
+    };
+    listGpgKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys"]["response"];
+    };
+    listGpgKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gpg_keys"]["response"];
+    };
+    listPublicEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/public_emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/public_emails"]["response"];
+    };
+    listPublicKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/keys"]["response"];
+    };
+    listPublicSshKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys"]["response"];
+    };
+    unfollow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/following/{username}"]["response"];
+    };
+    updateAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user"]["response"];
+    };
+  };
+};

--- a/src/generated/ghe-221-method-types.ts
+++ b/src/generated/ghe-221-method-types.ts
@@ -1,0 +1,6574 @@
+import { EndpointInterface, RequestInterface } from "@octokit/types";
+import { RestEndpointMethodTypes } from "./ghe-221-parameters-and-response-types";
+
+export type RestEndpointMethods = {
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#set-a-repository-subscription).
+     */
+    deleteRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Mutes all future notifications for a conversation until you comment on the thread or get an **@mention**. If you are watching the repository of the thread, you will still receive notifications. To ignore future notifications for a repository you are watching, use the [Set a thread subscription](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#set-a-thread-subscription) endpoint and set `ignore` to `true`.
+     */
+    deleteThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * GitHub Enterprise Server provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:
+     *
+     * *   **Timeline**: The GitHub Enterprise Server global public timeline
+     * *   **User**: The public timeline for any user, using [URI template](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#hypermedia)
+     * *   **Current user public**: The public timeline for the authenticated user
+     * *   **Current user**: The private timeline for the authenticated user
+     * *   **Current user actor**: The private timeline for activity created by the authenticated user
+     * *   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
+     * *   **Security advisories**: A collection of public announcements that provide information about security-related vulnerabilities in software on GitHub Enterprise Server.
+     *
+     * **Note**: Private feeds are only returned when [authenticating via Basic Auth](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication) since current feed URIs use the older, non revocable auth tokens.
+     */
+    getFeeds: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getFeeds"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getFeeds"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getThread: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThread"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getThread"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This checks to see if the current user is subscribed to a thread. You can also [get a repository subscription](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#get-a-repository-subscription).
+     *
+     * Note that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mentioned**, or manually subscribe to a thread.
+     */
+    getThreadSubscriptionForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+     */
+    listEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user, sorted by most recently updated.
+     */
+    listNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This is the user's organization dashboard. You must be authenticated as the user to view this.
+     */
+    listOrgEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * We delay the public events feed by five minutes, which means the most recent event returned by the public events API actually occurred at least five minutes ago.
+     */
+    listPublicEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForRepoNetwork: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicOrgEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.
+     */
+    listReceivedEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReceivedPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRepoEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user.
+     */
+    listRepoNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user is watching.
+     */
+    listReposWatchedByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people that have starred the repository.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/) via the `Accept` header:
+     */
+    listStargazersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user is watching.
+     */
+    listWatchedReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people watching the specified repository.
+     */
+    listWatchersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications as "read" removes it from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List notifications for the authenticated user](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#list-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications in a repository as "read" removes them from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List repository notifications for the authenticated user](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#list-repository-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markRepoNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    markThreadAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markThreadAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markThreadAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#delete-a-repository-subscription) completely.
+     */
+    setRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are watching a repository, you receive notifications for all threads by default. Use this endpoint to ignore future notifications for threads until you comment on the thread or get an **@mention**.
+     *
+     * You can also use this endpoint to subscribe to threads that you are currently not receiving notifications for or to subscribed to threads that you have previously ignored.
+     *
+     * Unsubscribing from a conversation in a repository that you are not watching is functionally equivalent to the [Delete a thread subscription](https://docs.github.com/enterprise-server@2.21/rest/reference/activity#delete-a-thread-subscription) endpoint.
+     */
+    setThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    starRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstarRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  apps: {
+    /**
+     * Add a single repository to an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@2.21/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    addRepoToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication) to use this endpoint, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.
+     */
+    checkToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["checkToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["checkToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated:** use `apps.createContentAttachmentForRepo()` (`POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments`) instead. Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://docs.github.com/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachment: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` and `repository` `full_name` of the content reference from the [`content_reference` event](https://docs.github.com/enterprise-server@2.21/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/enterprise-server@2.21/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachmentForRepo: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.
+     */
+    createFromManifest: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createFromManifest"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createFromManifest"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an installation access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token. By default the installation token has access to all repositories that the installation can access. To restrict the access to specific repositories, you can provide the `repository_ids` when creating the token. When you omit `repository_ids`, the response does not contain the `repositories` key.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    createInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid OAuth `access_token` as an input parameter and the grant for the token's owner will be deleted.
+     * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+     */
+    deleteAuthorization: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteAuthorization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteAuthorization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uninstalls a GitHub App on a user, organization, or business account. You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    deleteInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+     */
+    deleteToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["deleteToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the "[List installations for the authenticated app](https://docs.github.com/enterprise-server@2.21/rest/reference/apps#list-installations-for-the-authenticated-app)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).
+     *
+     * If the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    getBySlug: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getBySlug"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["getBySlug"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find an installation's information using the installation id. The installation's account type (`target_type`) will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the organization's installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getOrgInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getOrgInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getOrgInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getRepoInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getRepoInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getRepoInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the user’s installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getUserInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getUserInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getUserInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The access the user has to each repository is included in the hash under the `permissions` key.
+     */
+    listInstallationReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     *
+     * The permissions the installation has are included under the `permissions` key.
+     */
+    listInstallations: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You can find the permissions for the installation under the `permissions` key.
+     */
+    listInstallationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that an app installation can access.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    listReposAccessibleToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Remove a single repository from an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@2.21/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    removeRepoFromInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    resetToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["resetToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["resetToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Revokes the installation token you're using to authenticate as an installation and access this endpoint.
+     *
+     * Once an installation token is revoked, the token is invalidated and cannot be used. Other endpoints that require the revoked installation token must have a new installation token to work. You can create a new token using the "[Create an installation access token for an app](https://docs.github.com/enterprise-server@2.21/rest/reference/apps#create-an-installation-access-token-for-an-app)" endpoint.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    revokeInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  checks: {
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Creates a new check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to create check runs.
+     *
+     * In a check suite, GitHub limits the number of check runs with the same name to 1000. Once these check runs exceed 1000, GitHub will start to automatically delete older check runs.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * By default, check suites are automatically created when you create a [check run](https://docs.github.com/enterprise-server@2.21/rest/reference/checks#check-runs). You only need to use this endpoint for manually creating check suites when you've disabled automatic creation using "[Update repository preferences for check suites](https://docs.github.com/enterprise-server@2.21/rest/reference/checks#update-repository-preferences-for-check-suites)". Your GitHub App must have the `checks:write` permission to create check suites.
+     */
+    createSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["createSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["createSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    getSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["getSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["getSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.
+     */
+    listAnnotations: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listAnnotations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listAnnotations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    listSuitesForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listSuitesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listSuitesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository. This endpoint will trigger the [`check_suite` webhook](https://docs.github.com/enterprise-server@2.21/webhooks/event-payloads/#check_suite) event with the action `rerequested`. When a check suite is `rerequested`, its `status` is reset to `queued` and the `conclusion` is cleared.
+     *
+     * To rerequest a check suite, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.
+     */
+    rerequestSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["rerequestSuite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["rerequestSuite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://docs.github.com/enterprise-server@2.21/rest/reference/checks#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.
+     */
+    setSuitesPreferences: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Updates a check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to edit check runs.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getConductCode: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  emojis: {
+    /**
+     * Lists all the emojis available to use on GitHub Enterprise Server.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["emojis"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["emojis"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you boot a GitHub instance for the first time, you can use the following endpoint to upload a license:
+     *
+     * Note that you need to POST to [`/setup/api/configure`](https://docs.github.com/enterprise-server@2.21/rest/reference/enterprise-admin#start-a-configuration-process) to start the actual configuration process.
+     *
+     * When using this endpoint, your GitHub instance must have a password set. This can be accomplished two ways:
+     *
+     * 1.  If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
+     * 2.  If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
+     *
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@2.21/rest/reference/enterprise-admin#get-settings).
+     */
+    createEnterpriseServerLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If an external authentication mechanism is used, the login name should match the login name in the external system. If you are using LDAP authentication, you should also [update the LDAP mapping](https://docs.github.com/enterprise-server@2.21/rest/reference/enterprise-admin#update-ldap-mapping-for-a-user) for the user.
+     *
+     * The login name will be normalized to only contain alphanumeric characters or single hyphens. For example, if you send `"octo_cat"` as the login, a user named `"octo-cat"` will be created.
+     *
+     * If the login name or email address is already associated with an account, the server will return a `422` response.
+     */
+    createUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a personal access token. Returns a `403 - Forbidden` status when a personal access token is in use. For example, if you access this endpoint with the same personal access token that you are trying to delete, you will receive this error.
+     */
+    deletePersonalAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you attempt to delete an environment that cannot be deleted, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * *   _Cannot modify or delete the default environment_
+     * *   _Cannot delete environment that has hooks_
+     * *   _Cannot delete environment when download is in progress_
+     */
+    deletePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePublicKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a user will delete all their repositories, gists, applications, and personal settings. [Suspending a user](https://docs.github.com/enterprise-server@2.21/rest/reference/enterprise-admin#suspend-a-user) is often a better option.
+     *
+     * You can delete any user account except your own.
+     */
+    deleteUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can demote any user account except your own.
+     */
+    demoteSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The possible values for `enabled` are `true` and `false`. When it's `false`, the attribute `when` is ignored and the maintenance mode is turned off. `when` defines the time period when the maintenance was enabled.
+     *
+     * The possible values for `when` are `now` or any date parseable by [mojombo/chronic](https://github.com/mojombo/chronic).
+     */
+    enableOrDisableMaintenanceMode: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllAuthorizedSshKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommentStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to check the status of the most recent configuration process:
+     *
+     * Note that you may need to wait several seconds after you start a process before you can check its status.
+     *
+     * The different statuses are:
+     *
+     * | Status        | Description                       |
+     * | ------------- | --------------------------------- |
+     * | `PENDING`     | The job has not started yet       |
+     * | `CONFIGURING` | The job is running                |
+     * | `DONE`        | The job has finished correctly    |
+     * | `FAILED`      | The job has finished unexpectedly |
+     */
+    getConfigurationStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In addition to seeing the download status at the "[Get a pre-receive environment](#get-a-pre-receive-environment)" endpoint, there is also this separate endpoint for just the download status.
+     */
+    getDownloadStatusForPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getHooksStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getIssueStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLicenseInformation: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Check your installation's maintenance status:
+     */
+    getMaintenanceStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestoneStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getOrgStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPullRequestStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getUserStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listGlobalWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists personal access tokens for all users, including admin users.
+     */
+    listPersonalAccessTokens: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveEnvironments: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveHooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this organization as well as any disabled hooks that can be configured at the organization level. Globally disabled pre-receive hooks that do not allow downstream configuration are not listed.
+     */
+    listPreReceiveHooksForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this repository as well as any disabled hooks that are allowed to be enabled at the repository level. Pre-receive hooks that are disabled at a higher level and are not configurable will not be listed.
+     */
+    listPreReceiveHooksForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.21/webhooks/#ping-event) to be sent to the webhook.
+     */
+    pingGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    promoteUserToBeSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any overrides for this hook at the org level for this org.
+     */
+    removePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes any overridden enforcement on this repository for the specified hook.
+     *
+     * Responds with effective values inherited from owner and/or global level.
+     */
+    removePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@2.21/rest/reference/enterprise-admin#get-settings).
+     */
+    setSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to start a configuration process at any time for your updated settings to take effect:
+     */
+    startConfigurationProcess: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers a new download of the environment tarball from the environment's `image_url`. When the download is finished, the newly downloaded tarball will overwrite the existing environment.
+     *
+     * If a download cannot be triggered, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * * _Cannot modify or delete the default environment_
+     * * _Can not start a new download when a download is in progress_
+     */
+    startPreReceiveEnvironmentDownload: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), Active Directory LDAP-authenticated users cannot be suspended through this API. If you attempt to suspend an Active Directory LDAP-authenticated user through this API, it will return a `403` response.
+     *
+     * You can suspend any user account except your own.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    suspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), this API is disabled and will return a `403` response. Active Directory LDAP-authenticated users cannot be unsuspended using the API.
+     */
+    unsuspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Parameters that are not provided will be overwritten with the default value or removed if no default exists.
+     */
+    updateGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the [distinguished name](https://www.ldap.com/ldap-dns-and-rdns) (DN) of the LDAP entry to map to a team. [LDAP synchronization](https://help.github.com/enterprise/admin/guides/user-management/using-ldap/#enabling-ldap-sync) must be enabled to map LDAP entries to a team. Use the [Create a team](https://docs.github.com/enterprise-server@2.21/rest/reference/teams/#create-a-team) endpoint to create a team with LDAP mapping.
+     *
+     * You can also update the LDAP mapping of a child team.
+     */
+    updateLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateOrgName: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You cannot modify the default environment. If you attempt to modify the default environment, you will receive a `422 Unprocessable Entity` response.
+     */
+    updatePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updatePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the org level, you can set `enforcement` and `allow_downstream_configuration`
+     */
+    updatePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the repo level, you can set `enforcement`
+     */
+    updatePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateUsernameForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This API upgrades your license and also triggers the configuration process:
+     */
+    upgradeLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["checkIsStarred"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gists"]["checkIsStarred"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to add a new gist with one or more files.
+     *
+     * **Note:** Don't name your files "gistfile" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["createComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["createComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["deleteComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["deleteComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: This was previously `/gists/:gist_id/fork`.
+     */
+    fork: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["fork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["fork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    get: {
+      (params?: RestEndpointMethodTypes["gists"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["gists"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRevision: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getRevision"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getRevision"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the authenticated user's gists or if called anonymously, this endpoint returns all public gists:
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public gists for the specified user:
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List public gists sorted by most recently updated to least recently updated.
+     *
+     * Note: With [pagination](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the authenticated user's starred gists:
+     */
+    listStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listStarred"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listStarred"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    star: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["star"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["star"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstar: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["unstar"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["unstar"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to update or delete a gist file and rename gist files. Files from the previous version of the gist that aren't explicitly changed during an edit are unchanged.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["updateComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["updateComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  git: {
+    createBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reference for your repository. You are unable to create new references for empty repositories, even if the commit SHA-1 hash used exists. Empty repositories are repositories without branches.
+     */
+    createRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://docs.github.com/enterprise-server@2.21/rest/reference/git#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://docs.github.com/enterprise-server@2.21/rest/reference/git#create-a-reference) the tag reference - this call would be unnecessary.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The tree creation API accepts nested entries. If you specify both a tree and a nested path modifying that tree, this endpoint will overwrite the contents of the tree with the new path contents, and create a new tree structure.
+     *
+     * If you use this endpoint to add, delete, or modify the file contents in a tree, you will need to commit the tree and then update a branch to point to the commit. For more information see "[Create a commit](https://docs.github.com/enterprise-server@2.21/rest/reference/git#create-a-commit)" and "[Update a reference](https://docs.github.com/enterprise-server@2.21/rest/reference/git#update-a-reference)."
+     */
+    createTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["deleteRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["deleteRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `content` in the response will always be Base64 encoded.
+     *
+     * _Note_: This API supports blobs up to 100 megabytes in size.
+     */
+    getBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single reference from your Git database. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't match an existing ref, a `404` is returned.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.21/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     */
+    getRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single tree using the SHA1 value for that tree.
+     *
+     * If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+     */
+    getTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns an array of references from your Git database that match the supplied name. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't exist in the repository, but existing refs start with `:ref`, they will be returned as an array.
+     *
+     * When you use this endpoint without providing a `:ref`, it will return an array of all the references from your Git database, including notes and stashes if they exist on the server. Anything in the namespace is returned, not just `heads` and `tags`.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.21/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * If you request matching references for a branch named `feature` but the branch `feature` doesn't exist, the response can still include other matching head refs that start with the word `feature`, such as `featureA` and `featureB`.
+     */
+    listMatchingRefs: {
+      (
+        params?: RestEndpointMethodTypes["git"]["listMatchingRefs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["git"]["listMatchingRefs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["updateRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["updateRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gitignore: {
+    /**
+     * List all templates available to pass as an option when [creating a repository](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#create-a-repository-for-the-authenticated-user).
+     */
+    getAllTemplates: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API also allows fetching the source of a single template.
+     * Use the raw [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/) to get the raw contents.
+     */
+    getTemplate: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  issues: {
+    /**
+     * Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.
+     */
+    addAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addAssignees"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addAssignees"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    addLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks if a user has permission to be assigned to an issue in this repository.
+     *
+     * If the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.
+     *
+     * Otherwise a `404` status code is returned.
+     */
+    checkUserCanBeAssigned: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://help.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["createLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["deleteLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API returns a [`301 Moved Permanently` status](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-redirects-redirects) if the issue was
+     * [transferred](https://help.github.com/articles/transferring-an-issue-to-another-repository/) to another repository. If
+     * the issue was transferred to or deleted from a repository where the authenticated user lacks read access, the API
+     * returns a `404 Not Found` status. If the issue was deleted from a repository where the authenticated user has read
+     * access, the API returns a `410 Gone` status. To receive webhook events for transferred and deleted issues, subscribe
+     * to the [`issues`](https://docs.github.com/enterprise-server@2.21/webhooks/event-payloads/#issues) webhook.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getEvent: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getEvent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getEvent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getMilestone"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getMilestone"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues assigned to the authenticated user across all visible repositories including owned repositories, member
+     * repositories, and organization repositories. You can use the `filter` query parameter to fetch issues that are not
+     * necessarily assigned to you.
+     *
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.
+     */
+    listAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue Comments are ordered by ascending ID.
+     */
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * By default, Issue Comments are ordered by ascending ID.
+     */
+    listCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEvents: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEvents"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listEvents"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForTimeline: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues across owned and member repositories assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in an organization assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in a repository.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsOnIssue: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMilestones: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listMilestones"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listMilestones"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can lock an issue or pull request's conversation.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    lock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["lock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["lock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAllLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAllLabels"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAllLabels"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes one or more assignees from an issue.
+     */
+    removeAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the specified label from the issue, and returns the remaining labels on the issue. This endpoint returns a `404 Not Found` status if the label does not exist.
+     */
+    removeLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["removeLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any previous labels and sets the new labels for an issue.
+     */
+    setLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["setLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["setLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can unlock an issue's conversation.
+     */
+    unlock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["unlock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["unlock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue owners and users with push access can edit an issue.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  licenses: {
+    get: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllCommonlyUsed: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This method returns the contents of the repository's license file, if one is detected.
+     *
+     * Similar to [Get repository content](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#get-repository-content), this method also supports [custom media types](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types) for retrieving the raw license content or rendered license HTML.
+     */
+    getForRepo: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["getForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  markdown: {
+    render: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["render"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["render"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.
+     */
+    renderRaw: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["renderRaw"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["renderRaw"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  meta: {
+    get: {
+      (params?: RestEndpointMethodTypes["meta"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get the octocat as ASCII art
+     */
+    getOctocat: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getOctocat"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getOctocat"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a random sentence from the Zen of GitHub
+     */
+    getZen: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getZen"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getZen"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get Hypermedia links to resources accessible in GitHub's REST API
+     */
+    root: {
+      (params?: RestEndpointMethodTypes["meta"]["root"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["root"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  orgs: {
+    /**
+     * Check if a user is, publicly or privately, a member of the organization.
+     */
+    checkMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPublicMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see "[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)".
+     */
+    convertMemberToOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Here's how you can create a hook that posts payloads in JSON format:
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
+     *
+     * GitHub Apps with the `Organization plan` permission can use this endpoint to retrieve information about an organization's GitHub Enterprise Server plan. See "[Authenticating with GitHub Apps](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/authenticating-with-github-apps/)" for details. For an example response, see 'Response with GitHub Enterprise Server plan information' below."
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["orgs"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to get a user's membership with an organization, the authenticated user must be an organization member. The `state` parameter in the response can be used to identify the user's membership status.
+     */
+    getMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in an organization. To get only the webhook `config` properties, see "[Get a webhook configuration for an organization](/rest/reference/orgs#get-a-webhook-configuration-for-an-organization)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all organizations, in the order that they were created on GitHub Enterprise Server.
+     *
+     * **Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of organizations.
+     */
+    list: {
+      (params?: RestEndpointMethodTypes["orgs"]["list"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["list"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all GitHub Apps in an organization. The installation count includes all GitHub Apps installed on repositories in the organization. You must be an organization owner with `admin:read` scope to use this endpoint.
+     */
+    listAppInstallations: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listAppInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listAppInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List organizations for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * This only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.
+     *
+     * This method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List organizations for the authenticated user](https://docs.github.com/enterprise-server@2.21/rest/reference/orgs#list-organizations-for-the-authenticated-user) API instead.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
+     */
+    listMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembers"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listMembers"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMembershipsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are outside collaborators of an organization.
+     */
+    listOutsideCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Members of an organization can choose to have their membership publicized or not.
+     */
+    listPublicMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listPublicMembers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listPublicMembers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.21/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+     */
+    removeMember: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMember"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["removeMember"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to remove a user's membership with an organization, the authenticated user must be an organization owner.
+     *
+     * If the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.
+     */
+    removeMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all the organization's repositories.
+     */
+    removeOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removePublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Only authenticated organization owners can add a member to the organization or update the member's role.
+     *
+     * *   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](https://docs.github.com/enterprise-server@2.21/rest/reference/orgs#get-organization-membership-for-a-user) will be `pending` until they accept the invitation.
+     *
+     * *   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.
+     */
+    setMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The user can publicize their own membership. (A user cannot publicize the membership for another user.)
+     *
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    setPublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Parameter Deprecation Notice:** GitHub Enterprise Server will replace and discontinue `members_allowed_repository_creation_type` in favor of more granular permissions. The new input parameters are `members_can_create_public_repositories`, `members_can_create_private_repositories` for all organizations and `members_can_create_internal_repositories` for organizations associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. For more information, see the [blog post](https://developer.github.com/changes/2019-12-03-internal-visibility-changes).
+     *
+     * Enables an authenticated organization owner with the `admin:org` scope to update the organization's profile and member privileges.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in an organization. When you update a webhook, the `secret` will be overwritten. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for an organization](/rest/reference/orgs#update-a-webhook-configuration-for-an-organization)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  projects: {
+    /**
+     * Adds a collaborator to an organization project and sets their permission level. You must be an organization owner or a project `admin` to add a collaborator.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["createCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an organization project board. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a repository project board. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a project board. Returns a `404 Not Found` status if projects are disabled.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["deleteCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["deleteColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a project by its `id`. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the collaborator's permission level for an organization project. Possible values for the `permission` key: `admin`, `write`, `read`, `none`. You must be an organization owner or a project `admin` to review a user's permission level.
+     */
+    getPermissionForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getPermissionForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["getPermissionForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCards: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCards"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listCards"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listColumns: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listColumns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listColumns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a collaborator from an organization project. You must be an organization owner or a project `admin` to remove a collaborator.
+     */
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a project board's information. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["updateCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["updateColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["checkIfMerged"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["checkIfMerged"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team, GitHub Enterprise Server 2.17+, and GitHub Enterprise Cloud. You can create a new pull request. This endpoint triggers [notifications](https://docs.github.com/articles/about-notifications/). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reply to a review comment for a pull request. For the `comment_id`, provide the ID of the review comment you are replying to. This must be the ID of a _top-level review comment_, not a reply to that comment. Replies to replies are not supported.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReplyForReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * Pull request reviews created in the `PENDING` state do not include the `submitted_at` property in the response.
+     *
+     * **Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#get-a-pull-request) endpoint.
+     *
+     * The `position` value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     */
+    createReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["createReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a review comment in the pull request diff. To add a regular comment to a pull request timeline, see "[Create an issue comment](https://docs.github.com/enterprise-server@2.21/rest/reference/issues#create-an-issue-comment)." We recommend creating a review comment using `line`, `side`, and optionally `start_line` and `start_side` if your comment applies to more than one line in the pull request diff.
+     *
+     * You can still create a review comment using the `position` parameter. When you use `position`, the `line`, `side`, `start_line`, and `start_side` parameters are not required. For more information, see the [`comfort-fade` preview notice](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#create-a-review-comment-for-a-pull-request-preview-notices).
+     *
+     * **Note:** The position value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePendingReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deletePendingReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deletePendingReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a review comment.
+     */
+    deleteReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** To dismiss a pull request review on a [protected branch](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#branches), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.
+     */
+    dismissReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["dismissReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["dismissReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists details of a pull request by providing its number.
+     *
+     * When you get, [create](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls/#create-a-pull-request), or [edit](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#update-a-pull-request) a pull request, GitHub Enterprise Server creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.21/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub Enterprise Server has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the _test_ merge commit.
+     *
+     * The value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
+     *
+     * *   If merged as a [merge commit](https://help.github.com/articles/about-merge-methods-on-github/), `merge_commit_sha` represents the SHA of the merge commit.
+     * *   If merged via a [squash](https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits), `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
+     * *   If [rebased](https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits), `merge_commit_sha` represents the commit that the base branch was updated to.
+     *
+     * Pass the appropriate [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["pulls"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["pulls"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["getReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides details for a review comment.
+     */
+    getReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["getReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team, GitHub Enterprise Server 2.17+, and GitHub Enterprise Cloud.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List comments for a specific pull request review.
+     */
+    listCommentsForReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a maximum of 250 commits for a pull request. To receive a complete commit list for pull requests with more than 250 commits, use the [List commits](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#list-commits) endpoint.
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** Responses include a maximum of 3000 files. The paginated response returns 30 files per page by default.
+     */
+    listFiles: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listFiles"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
+     */
+    listReviewComments: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewComments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
+     */
+    listReviewCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The list of reviews returns in chronological order.
+     */
+    listReviews: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviews"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@2.21/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@2.21/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    requestReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["requestReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["requestReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    submitReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["submitReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["submitReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team, GitHub Enterprise Server 2.17+, and GitHub Enterprise Cloud.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch.
+     */
+    updateBranch: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Update the review summary comment with new text.
+     */
+    updateReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables you to edit a review comment.
+     */
+    updateReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["updateReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  rateLimit: {
+    /**
+     * **Note:** Accessing this endpoint does not count against your REST API rate limit.
+     *
+     * **Note:** The `rate` object is deprecated. If you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["rateLimit"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["rateLimit"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  reactions: {
+    /**
+     * Create a reaction to a [commit comment](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#comments). A response with an HTTP `200` status means that you already added the reaction type to this commit comment.
+     */
+    createForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue](https://docs.github.com/enterprise-server@2.21/rest/reference/issues/). A response with an HTTP `200` status means that you already added the reaction type to this issue.
+     */
+    createForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue comment](https://docs.github.com/enterprise-server@2.21/rest/reference/issues#comments). A response with an HTTP `200` status means that you already added the reaction type to this issue comment.
+     */
+    createForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#comments). A response with an HTTP `200` status means that you already added the reaction type to this pull request review comment.
+     */
+    createForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion comment.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    createForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    createForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [commit comment](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#comments).
+     */
+    deleteForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/issues/:issue_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue](https://docs.github.com/enterprise-server@2.21/rest/reference/issues/).
+     */
+    deleteForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE delete /repositories/:repository_id/issues/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue comment](https://docs.github.com/enterprise-server@2.21/rest/reference/issues#comments).
+     */
+    deleteForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/pulls/comments/:comment_id/reactions/:reaction_id.`
+     *
+     * Delete a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#review-comments).
+     */
+    deleteForPullRequestComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Reactions API. We recommend migrating your existing code to use the new delete reactions endpoints. For more information, see this [blog post](https://developer.github.com/changes/2020-02-26-new-delete-reactions-endpoints/).
+     *
+     * OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), when deleting a [team discussion](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussions) or [team discussion comment](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussion-comments).
+     * @deprecated octokit.rest.reactions.deleteLegacy() is deprecated, see https://docs.github.com/enterprise-server@2.21/rest/reference/reactions/#delete-a-reaction-legacy
+     */
+    deleteLegacy: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteLegacy"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteLegacy"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [commit comment](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#comments).
+     */
+    listForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue](https://docs.github.com/enterprise-server@2.21/rest/reference/issues).
+     */
+    listForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue comment](https://docs.github.com/enterprise-server@2.21/rest/reference/issues#comments).
+     */
+    listForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [pull request review comment](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#review-comments).
+     */
+    listForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion comment](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussion-comments/). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    listForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#discussions). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    listForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["acceptInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["acceptInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified apps push access for this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * For more information the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * The invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#invitations).
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    addStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified teams push access for this branch. You can also give push access to child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified people push access for this branch.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    checkCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["checkCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["checkCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated**: Use `repos.compareCommitsWithBasehead()` (`GET /repos/{owner}/{repo}/compare/{basehead}`) instead. Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * To process a response with a large number of commits, you can use (`per_page` or `page`) to paginate the results. When using paging, the list of changed files is only returned with page 1, but includes all changed files for the entire comparison. For more information on working with pagination, see "[Traversing with pagination](/rest/guides/traversing-with-pagination)."
+     *
+     * When calling this API without any paging parameters (`per_page` or `page`), the returned list is limited to 250 commits and the last commit in the list is the most recent of the entire comparison. When a paging parameter is specified, the first commit in the returned list of each page is the earliest.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommits"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommits"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `basehead` param is comprised of two parts: `base` and `head`. Both must be branch names in `repo`. To compare branches across other repositories in the same network as `repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * The response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [List commits](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#list-commits) to enumerate all commits in the range.
+     *
+     * For comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long
+     * to generate. You can typically resolve this error by using a smaller commit range.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommitsWithBasehead: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a comment for a commit using its `:commit_sha`.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to require signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    createCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access in a repository can create commit statuses for a given SHA.
+     *
+     * Note: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.
+     */
+    createCommitStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can create a read-only deploy key.
+     */
+    createDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deployments offer a few configurable parameters with certain defaults.
+     *
+     * The `ref` parameter can be any named branch, tag, or SHA. At GitHub Enterprise Server we often deploy branches and verify them
+     * before we merge a pull request.
+     *
+     * The `environment` parameter allows deployments to be issued to different runtime environments. Teams often have
+     * multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This parameter
+     * makes it easier to track which environments have requested deployments. The default environment is `production`.
+     *
+     * The `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If
+     * the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds,
+     * the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will
+     * return a failure response.
+     *
+     * By default, [commit statuses](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#statuses) for every submitted context must be in a `success`
+     * state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to
+     * specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do
+     * not require any contexts or create any commit statuses, the deployment will always succeed.
+     *
+     * The `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text
+     * field that will be passed on when a deployment event is dispatched.
+     *
+     * The `task` parameter is used by the deployment system to allow different execution paths. In the web world this might
+     * be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an
+     * application with debugging enabled.
+     *
+     * Users with `repo` or `repo_deployment` scopes can create a deployment for a given ref.
+     *
+     * #### Merged branch response
+     * You will see this response when GitHub automatically merges the base branch into the topic branch instead of creating
+     * a deployment. This auto-merge happens when:
+     * *   Auto-merge option is enabled in the repository
+     * *   Topic branch does not include the latest changes on the base branch, which is `master` in the response example
+     * *   There are no merge conflicts
+     *
+     * If there are no new commits in the base branch, a new request to create a deployment should give a successful
+     * response.
+     *
+     * #### Merge conflict response
+     * This error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't
+     * be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.
+     *
+     * #### Failed commit status checks
+     * This error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success`
+     * status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.
+     */
+    createDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with `push` access can create deployment statuses for a given deployment.
+     *
+     * GitHub Apps require `read & write` access to "Deployments" and `read-only` access to "Repo contents" (for private repos). OAuth Apps require the `repo_deployment` scope.
+     */
+    createDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to trigger a webhook event called `repository_dispatch` when you want activity that happens outside of GitHub Enterprise Server to trigger a GitHub Actions workflow or GitHub App webhook. You must configure your GitHub Actions workflow or GitHub App to run when the `repository_dispatch` event occurs. For an example `repository_dispatch` webhook payload, see "[RepositoryDispatchEvent](https://docs.github.com/enterprise-server@2.21/webhooks/event-payloads/#repository_dispatch)."
+     *
+     * The `client_payload` parameter is available for any extra information that your workflow might need. This parameter is a JSON payload that will be passed on when the webhook event is dispatched. For example, the `client_payload` can include a message that a user would like to send using a GitHub Actions workflow. Or the `client_payload` can be used as a test to debug your workflow.
+     *
+     * This endpoint requires write access to the repository by providing either:
+     *
+     *   - Personal access tokens with `repo` scope. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)" in the GitHub Help documentation.
+     *   - GitHub Apps with both `metadata:read` and `contents:read&write` permissions.
+     *
+     * This input example shows how you can use the `client_payload` as a test to debug your workflow.
+     */
+    createDispatchEvent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDispatchEvent"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDispatchEvent"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository.
+     */
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a fork for the authenticated user.
+     *
+     * **Note**: Forking a Repository happens asynchronously. You may have to wait a short period of time before you can access the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub Enterprise Server Support](https://support.github.com/contact) or [GitHub Enterprise Server Premium Support](https://premium.githubsupport.com).
+     */
+    createFork: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createFork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createFork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository in the specified organization. The authenticated user must be a member of the organization.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createInOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new file or replaces an existing file in a repository.
+     */
+    createOrUpdateFileContents: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Configures a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages)."
+     */
+    createPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can create a release.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository using a repository template. Use the `template_owner` and `template_repo` route parameters to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the [Get a repository](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#get-a-repository) endpoint and check that the `is_template` key is `true`.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createUsingTemplate: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createUsingTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createUsingTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can
+     * share the same `config` as long as those webhooks do not have any `events` that overlap.
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    declineInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["declineInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["declineInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+     *
+     * If an organization owner has configured the organization to prevent members from deleting organization-owned
+     * repositories, you will get a `403 Forbidden` response.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Disables the ability to restrict who can push to this branch.
+     */
+    deleteAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    deleteAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deleteBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to disable required signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    deleteCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
+     */
+    deleteDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To ensure there can always be an active deployment, you can only delete an _inactive_ deployment. Anyone with `repo` or `repo_deployment` scopes can delete an inactive deployment.
+     *
+     * To set a deployment as inactive, you must:
+     *
+     * *   Create a new deployment that is active so that the system has a record of the current state, then delete the previously active deployment.
+     * *   Mark the active deployment as inactive by adding any non-successful deployment status.
+     *
+     * For more information, see "[Create a deployment](https://docs.github.com/enterprise-server@2.21/rest/reference/repos/#create-a-deployment)" and "[Create a deployment status](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#create-a-deployment-status)."
+     */
+    deleteDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a file in a repository.
+     *
+     * You can provide an additional `committer` parameter, which is an object containing information about the committer. Or, you can provide an `author` parameter, which is an object containing information about the author.
+     *
+     * The `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.
+     *
+     * You must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.
+     */
+    deleteFile: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteFile"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteFile"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deletePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can delete a release.
+     */
+    deleteRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a tar archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadTarballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a zip archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadZipballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you pass the `scarlet-witch-preview` media type, requests to get a repository will also return the repository's code of conduct if it can be detected from the repository's code of conduct file.
+     *
+     * The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["repos"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["repos"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists who has access to this protected branch.
+     *
+     * **Note**: Users, apps, and teams `restrictions` are only available for organization-owned repositories.
+     */
+    getAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAllStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllTopics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getAllTopics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the GitHub Apps that have push access to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     */
+    getAppsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+     */
+    getCodeFrequencyStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks the repository permission of a collaborator. The possible repository permissions are `admin`, `write`, `read`, and `none`.
+     */
+    getCollaboratorPermissionLevel: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
+     *
+     * The most recent status for each context is returned, up to 100. This field [paginates](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination) if there are over 100 contexts.
+     *
+     * Additionally, a combined `state` is returned. The `state` is one of:
+     *
+     * *   **failure** if any of the contexts report as `error` or `failure`
+     * *   **pending** if there are no statuses or a context is `pending`
+     * *   **success** if the latest status for all contexts is `success`
+     */
+    getCombinedStatusForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the contents of a single commit reference. You must have `read` access for the repository to use this endpoint.
+     *
+     * **Note:** If there are more than 300 files in the commit diff, the response will include pagination link headers for the remaining files, up to a limit of 3000 files. Each page contains the static commit information, and the only changes are to the file listing.
+     *
+     * You can pass the appropriate [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to  fetch `diff` and `patch` formats. Diffs with binary data will have no `patch` property.
+     *
+     * To return only the SHA-1 hash of the commit reference, you can provide the `sha` custom [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) in the `Accept` header. You can use this endpoint to check if a remote reference's SHA-1 hash is the same as your local reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.
+     */
+    getCommitActivityStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to check whether a branch requires signed commits. An enabled status of `true` indicates you must sign commits on this branch. For more information, see [Signing commits with GPG](https://help.github.com/articles/signing-commits-with-gpg) in GitHub Help.
+     *
+     * **Note**: You must enable branch protection to require signed commits.
+     */
+    getCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the contents of a file or directory in a repository. Specify the file path or directory in `:path`. If you omit
+     * `:path`, you will receive the contents of the repository's root directory. See the description below regarding what the API response includes for directories.
+     *
+     * Files and symlinks support [a custom media type](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#custom-media-types) for
+     * retrieving the raw content or rendered HTML (when supported). All content types support [a custom media
+     * type](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#custom-media-types) to ensure the content is returned in a consistent
+     * object format.
+     *
+     * **Note**:
+     * *   To get a repository's contents recursively, you can [recursively get the tree](https://docs.github.com/enterprise-server@2.21/rest/reference/git#trees).
+     * *   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees
+     * API](https://docs.github.com/enterprise-server@2.21/rest/reference/git#get-a-tree).
+     * *   This API supports files up to 1 megabyte in size.
+     *
+     * #### If the content is a directory
+     * The response will be an array of objects, one object for each item in the directory.
+     * When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value
+     * _should_ be "submodule". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW).
+     * In the next major version of the API, the type will be returned as "submodule".
+     *
+     * #### If the content is a symlink
+     * If the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the
+     * API responds with the content of the file (in the format shown in the example. Otherwise, the API responds with an object
+     * describing the symlink itself.
+     *
+     * #### If the content is a submodule
+     * The `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific
+     * commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out
+     * the submodule at that specific commit.
+     *
+     * If the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links["git"]`) and the
+     * github.com URLs (`html_url` and `_links["html"]`) will have null values.
+     */
+    getContent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getContent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the `total` number of commits authored by the contributor. In addition, the response includes a Weekly Hash (`weeks` array) with the following information:
+     *
+     * *   `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+     * *   `a` - Number of additions
+     * *   `d` - Number of deletions
+     * *   `c` - Number of commits
+     */
+    getContributorsStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContributorsStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getContributorsStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployKey"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployKey"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view a deployment status for a deployment:
+     */
+    getDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLatestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View the latest published full release for the repository.
+     *
+     * The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
+     */
+    getLatestRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestRelease"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestRelease"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPagesBuild"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPagesBuild"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.
+     *
+     * The array order is oldest week (index 0) to most recent week.
+     */
+    getParticipationStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getParticipationStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getParticipationStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getPullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Each array contains the day number, hour number, and number of commits:
+     *
+     * *   `0-6`: Sunday - Saturday
+     * *   `0-23`: Hour of day
+     * *   Number of commits
+     *
+     * For example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+     */
+    getPunchCardStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPunchCardStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPunchCardStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the preferred README for a repository.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadme: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadme"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getReadme"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the README from a repository directory.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadmeInDirectory: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#hypermedia).
+     */
+    getRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.
+     */
+    getReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a published release with the specified tag.
+     */
+    getReleaseByTag: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseByTag"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getStatusChecksProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the teams who have push access to this branch. The list includes child teams.
+     */
+    getTeamsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the people who have push access to this branch.
+     */
+    getUsersWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in a repository. To get only the webhook `config` properties, see "[Get a webhook configuration for a repository](/rest/reference/repos#get-a-webhook-configuration-for-a-repository)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listBranches: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranches"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listBranches"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Returns all branches where the given commit SHA is the HEAD, or latest commit for the branch.
+     */
+    listBranchesForHeadCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use the `:commit_sha` to specify the commit that will have its comments listed.
+     */
+    listCommentsForCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Commit Comments use [these custom media types](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#custom-media-types). You can read more about the use of media types in the API [here](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/).
+     *
+     * Comments are ordered by ascending ID.
+     */
+    listCommitCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.
+     *
+     * This resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.
+     */
+    listCommitStatusesForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
+     *
+     * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
+     */
+    listContributors: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listContributors"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listContributors"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listDeployKeys: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view deployment statuses for a deployment:
+     */
+    listDeploymentStatuses: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Simple filtering of deployments is available via query parameters:
+     */
+    listDeployments: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories for the specified organization.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public repositories for the specified user. Note: For GitHub AE, this endpoint will list internal repositories for the specified user.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.
+     */
+    listInvitations: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user, this endpoint will list all currently open repository invitations for that user.
+     */
+    listInvitationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.
+     */
+    listLanguages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listLanguages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listLanguages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPagesBuilds: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPagesBuilds"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPagesBuilds"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all public repositories in the order that they were created.
+     *
+     * Note:
+     * - For GitHub Enterprise Server, this endpoint will only list repositories available to all users on the enterprise.
+     * - Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of repositories.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, additionally returns open pull requests associated with the commit. The results may include open and closed pull requests. Additional preview headers may be required to see certain details for associated pull requests, such as whether a pull request is in a draft state. For more information about previews that might affect this endpoint, see the [List pull requests](https://docs.github.com/enterprise-server@2.21/rest/reference/pulls#list-pull-requests) endpoint.
+     */
+    listPullRequestsAssociatedWithCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReleaseAssets: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleaseAssets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#list-repository-tags).
+     *
+     * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+     */
+    listReleases: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleases"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listReleases"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTags: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTags"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTags"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTeams: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTeams"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTeams"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.21/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of an app to push to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a team to push to this branch. You can also remove push access for child teams.
+     *
+     * | Type    | Description                                                                                                                                         |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a user to push to this branch.
+     *
+     * | Type    | Description                                                                                                                                   |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames of the people who should no longer have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    replaceAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["replaceAllTopics"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["replaceAllTopics"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.
+     *
+     * Build requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.
+     */
+    requestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["requestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["requestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    setAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of apps that have push access to this branch. This removes all apps that previously had push access and grants push access to the new list of apps. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    setStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. Team restrictions include child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.
+     *
+     * **Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`
+     */
+    testPushWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["testPushWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["testPushWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * A transfer request will need to be accepted by the new owner when transferring a personal repository to another user. The response will contain the original `owner`, and the transfer will continue asynchronously. For more details on the requirements to transfer personal and organization-owned repositories, see [about repository transfers](https://help.github.com/articles/about-repository-transfers/).
+     */
+    transfer: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["transfer"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["transfer"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: To edit a repository's topics, use the [Replace all repository topics](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#replace-all-repository-topics) endpoint.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Protecting a branch requires admin or owner permissions to the repository.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     *
+     * **Note**: The list of users, apps, and teams in total is limited to 100 items.
+     */
+    updateBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates information for a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages).
+     */
+    updateInformationAboutPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     */
+    updatePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release.
+     */
+    updateRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release asset.
+     */
+    updateReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    updateStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in a repository. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for a repository](/rest/reference/repos#update-a-webhook-configuration-for-a-repository)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint makes use of [a Hypermedia relation](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#hypermedia) to determine which URL to access. The endpoint you call to upload release assets is specific to your release. Use the `upload_url` returned in
+     * the response of the [Create a release endpoint](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#create-a-release) to upload a release asset.
+     *
+     * You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.
+     *
+     * Most libraries will set the required `Content-Length` header automatically. Use the required `Content-Type` header to provide the media type of the asset. For a list of media types, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). For example:
+     *
+     * `application/zip`
+     *
+     * GitHub Enterprise Server expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body. Everything else about the endpoint is the same as the rest of the API. For example,
+     * you'll still need to pass your authentication to be able to upload an asset.
+     *
+     * When an upstream failure occurs, you will receive a `502 Bad Gateway` status. This may leave an empty asset with a state of `starter`. It can be safely deleted.
+     *
+     * **Notes:**
+     * *   GitHub Enterprise Server renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "[List assets for a release](https://docs.github.com/enterprise-server@2.21/rest/reference/repos#list-assets-for-a-release)"
+     * endpoint lists the renamed filenames. For more information and help, contact [GitHub Enterprise Server Support](https://support.github.com/contact).
+     * *   If you upload an asset with the same filename as another uploaded asset, you'll receive an error and must delete the old file before you can re-upload the new asset.
+     */
+    uploadReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  search: {
+    /**
+     * Searches for query terms inside of a file. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for code, you can get text match metadata for the file **content** and file **path** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery) repository, your query would look something like this:
+     *
+     * `q=addClass+in:file+language:js+repo:jquery/jquery`
+     *
+     * This query searches for the keyword `addClass` within a file's contents. The query limits the search to files where the language is JavaScript in the `jquery/jquery` repository.
+     *
+     * #### Considerations for code search
+     *
+     * Due to the complexity of searching code, there are a few restrictions on how searches are performed:
+     *
+     * *   Only the _default branch_ is considered. In most cases, this will be the `master` branch.
+     * *   Only files smaller than 384 KB are searchable.
+     * *   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing
+     * language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.
+     */
+    code: {
+      (
+        params?: RestEndpointMethodTypes["search"]["code"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["code"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find commits via various criteria on the default branch (usually `master`). This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for commits, you can get text match metadata for the **message** field when you provide the `text-match` media type. For more details about how to receive highlighted search results, see [Text match
+     * metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:
+     *
+     * `q=repo:octocat/Spoon-Knife+css`
+     */
+    commits: {
+      (
+        params?: RestEndpointMethodTypes["search"]["commits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["commits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find issues by state and keyword. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields when you pass the `text-match` media type. For more details about how to receive highlighted
+     * search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.
+     *
+     * `q=windows+label:bug+language:python+state:open&sort=created&order=asc`
+     *
+     * This query searches for the keyword `windows`, within any open issue that is labeled as `bug`. The search runs across repositories whose primary language is Python. The results are sorted by creation date in ascending order, which means the oldest issues appear first in the search results.
+     *
+     * **Note:** For [user-to-server](https://docs.github.com/developers/apps/identifying-and-authorizing-users-for-github-apps#user-to-server-requests) GitHub App requests, you can't retrieve a combination of issues and pull requests in a single query. Requests that don't include the `is:issue` or `is:pull-request` qualifier will receive an HTTP `422 Unprocessable Entity` response. To get results for both issues and pull requests, you must send separate queries for issues and pull requests. For more information about the `is` qualifier, see "[Searching only issues or pull requests](https://docs.github.com/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-only-issues-or-pull-requests)."
+     */
+    issuesAndPullRequests: {
+      (
+        params?: RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find labels in a repository with names or descriptions that match search keywords. Returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for labels, you can get text match metadata for the label **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find labels in the `linguist` repository that match `bug`, `defect`, or `enhancement`. Your query might look like this:
+     *
+     * `q=bug+defect+enhancement&repository_id=64778136`
+     *
+     * The labels that best match the query appear first in the search results.
+     */
+    labels: {
+      (
+        params?: RestEndpointMethodTypes["search"]["labels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["labels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find repositories via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for repositories, you can get text match metadata for the **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for popular Tetris repositories written in assembly code, your query might look like this:
+     *
+     * `q=tetris+language:assembly&sort=stars&order=desc`
+     *
+     * This query searches for repositories with the word `tetris` in the name, the description, or the README. The results are limited to repositories where the primary language is assembly. The results are sorted by stars in descending order, so that the most popular repositories appear first in the search results.
+     *
+     * When you include the `mercy` preview header, you can also search for multiple topics by adding more `topic:` instances. For example, your query might look like this:
+     *
+     * `q=topic:ruby+topic:rails`
+     */
+    repos: {
+      (
+        params?: RestEndpointMethodTypes["search"]["repos"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["repos"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find topics via various criteria. Results are sorted by best match. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination). See "[Searching topics](https://help.github.com/articles/searching-topics/)" for a detailed list of qualifiers.
+     *
+     * When searching for topics, you can get text match metadata for the topic's **short\_description**, **description**, **name**, or **display\_name** field when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for topics related to Ruby that are featured on https://github.com/topics. Your query might look like this:
+     *
+     * `q=ruby+is:featured`
+     *
+     * This query searches for topics with the keyword `ruby` and limits the results to find only topics that are featured. The topics that are the best match for the query appear first in the search results.
+     */
+    topics: {
+      (
+        params?: RestEndpointMethodTypes["search"]["topics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["topics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find users via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields when you pass the `text-match` media type. For more details about highlighting search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata). For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.21/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you're looking for a list of popular users, you might try this query:
+     *
+     * `q=tom+repos:%3E42+followers:%3E1000`
+     *
+     * This query searches for users with the name `tom`. The results are restricted to users with more than 42 repositories and over 1,000 followers.
+     */
+    users: {
+      (
+        params?: RestEndpointMethodTypes["search"]["users"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["users"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  teams: {
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adds an organization member to a team. An authenticated organization owner or team maintainer can add organization members to a team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * An organization owner can add someone who is not part of the team's organization to a team. When an organization owner adds someone to a team who is not an organization member, this endpoint will send an invitation to the person via email. This newly-created membership will be in the "pending" state until the person accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team.
+     *
+     * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    addOrUpdateMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    addOrUpdateProjectPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     *
+     * For more information about the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     */
+    addOrUpdateRepoPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    checkPermissionsForProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `admin`, `push`, `maintain`, `triage`, or `pull` permission for a repository. Repositories inherited through a parent team will also be checked.
+     *
+     * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://docs.github.com/enterprise-server@2.21/rest/overview/media-types/) via the `application/vnd.github.v3.repository+json` accept header.
+     *
+     * If a team doesn't have permission for the repository, you will receive a `404 Not Found` response status.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    checkPermissionsForRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams. Organization owners can limit team creation to organization owners. For more information, see "[Setting team creation permissions](https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization)."
+     *
+     * When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of `maintainers`. For more information, see "[About teams](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    createDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.21/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    createDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    deleteDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    deleteDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To delete a team, the authenticated user must be an organization owner or team maintainer.
+     *
+     * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}`.
+     */
+    deleteInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["deleteInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a team using the team's `slug`. GitHub Enterprise Server generates the `slug` from the team `name`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}`.
+     */
+    getByName: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getByName"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["getByName"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    getDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    getDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To get a user's membership with a team, the team must be visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     *
+     * **Note:**
+     * The response contains the `state` of the membership and the member's `role`.
+     *
+     * The `role` for organization owners is set to `maintainer`. For more information about `maintainer` roles, see see [Create a team](https://docs.github.com/enterprise-server@2.21/rest/reference/teams#create-a-team).
+     */
+    getMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all teams in an organization that are visible to the authenticated user.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the child teams of the team specified by `{team_slug}`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/teams`.
+     */
+    listChildInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listChildInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listChildInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    listDiscussionCommentsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    listDiscussionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/).
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To list members in a team, the team must be visible to the authenticated user.
+     */
+    listMembersInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listMembersInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listMembersInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organization projects for a team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects`.
+     */
+    listProjectsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a team's repositories visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos`.
+     */
+    listReposInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listReposInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listReposInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    removeMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. This endpoint removes the project from the team, but does not delete the project.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    removeProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. This does not delete the repository, it just removes it from the team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    removeRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    updateDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    updateDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}`.
+     */
+    updateInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["updateInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  users: {
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    addEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPersonIsFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a GPG key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    deleteEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GPG key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deletePublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    follow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["follow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["follow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is authenticated through basic authentication or OAuth with the `user` scope, then the response lists public and private profile information.
+     *
+     * If the authenticated user is authenticated through OAuth without the `user` scope, then the response lists only public profile information.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides publicly available information about someone with a GitHub account.
+     *
+     * GitHub Apps with the `Plan` user permission can use this endpoint to retrieve information about a user's GitHub Enterprise Server plan. The GitHub App must be authenticated as a user. See "[Identifying and authorizing users for GitHub Apps](https://docs.github.com/enterprise-server@2.21/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)" for details about authentication. For an example response, see 'Response with GitHub Enterprise Server plan information' below"
+     *
+     * The `email` key in the following response is the publicly visible email address from your GitHub Enterprise Server [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub Enterprise Server. For more information, see [Authentication](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#authentication).
+     *
+     * The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "[Emails API](https://docs.github.com/enterprise-server@2.21/rest/reference/users#emails)".
+     */
+    getByUsername: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getByUsername"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["getByUsername"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides hovercard information when authenticated through basic auth or OAuth with the `repo` scope. You can find out more about someone in relation to their pull requests, issues, repositories, and organizations.
+     *
+     * The `subject_type` and `subject_id` parameters provide context for the person's hovercard, which returns more information than without the parameters. For example, if you wanted to find out more about `octocat` who owns the `Spoon-Knife` repository via cURL, it would look like this:
+     *
+     * ```shell
+     *  curl -u username:token
+     *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
+     * ```
+     */
+    getContextForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getContextForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getContextForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all users, in the order that they signed up on GitHub Enterprise Server. This list includes personal user accounts and organization accounts.
+     *
+     * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.21/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of users.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["users"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.
+     */
+    listEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the authenticated user follows.
+     */
+    listFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the authenticated user.
+     */
+    listFollowersForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the specified user.
+     */
+    listFollowersForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the specified user follows.
+     */
+    listFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listGpgKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the GPG keys for a user. This information is accessible by anyone.
+     */
+    listGpgKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists your publicly visible email address, which you can set with the [Set primary email visibility for the authenticated user](https://docs.github.com/enterprise-server@2.21/rest/reference/users#set-primary-email-visibility-for-the-authenticated-user) endpoint. This endpoint is accessible with the `user:email` scope.
+     */
+    listPublicEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the _verified_ public SSH keys for a user. This is accessible by anyone.
+     */
+    listPublicKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@2.21/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listPublicSshKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    unfollow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["unfollow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["unfollow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.
+     */
+    updateAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["updateAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["updateAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+};

--- a/src/generated/ghe-221-parameters-and-response-types.ts
+++ b/src/generated/ghe-221-parameters-and-response-types.ts
@@ -1,0 +1,4144 @@
+import { Endpoints, RequestParameters } from "@octokit/types";
+
+export type RestEndpointMethodTypes = {
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred/{owner}/{repo}"]["response"];
+    };
+    deleteRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    deleteThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    getFeeds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /feeds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /feeds"]["response"];
+    };
+    getRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    getThread: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}"]["response"];
+    };
+    getThreadSubscriptionForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    listEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events"]["response"];
+    };
+    listNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications"]["response"];
+    };
+    listOrgEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/orgs/{org}"]["response"];
+    };
+    listPublicEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /events"]["response"];
+    };
+    listPublicEventsForRepoNetwork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /networks/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /networks/{owner}/{repo}/events"]["response"];
+    };
+    listPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/public"]["response"];
+    };
+    listPublicOrgEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/events"]["response"];
+    };
+    listReceivedEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events"]["response"];
+    };
+    listReceivedPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events/public"]["response"];
+    };
+    listRepoEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/events"]["response"];
+    };
+    listRepoNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    listReposStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred"]["response"];
+    };
+    listReposStarredByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/starred"]["response"];
+    };
+    listReposWatchedByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/subscriptions"]["response"];
+    };
+    listStargazersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stargazers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stargazers"]["response"];
+    };
+    listWatchedReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/subscriptions"]["response"];
+    };
+    listWatchersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscribers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscribers"]["response"];
+    };
+    markNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications"]["response"];
+    };
+    markRepoNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    markThreadAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /notifications/threads/{thread_id}"]["response"];
+    };
+    setRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    setThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    starRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/starred/{owner}/{repo}"]["response"];
+    };
+    unstarRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/starred/{owner}/{repo}"]["response"];
+    };
+  };
+  apps: {
+    addRepoToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    checkToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /applications/{client_id}/token"]["response"];
+    };
+    createContentAttachment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createContentAttachmentForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createFromManifest: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app-manifests/{code}/conversions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app-manifests/{code}/conversions"]["response"];
+    };
+    createInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app/installations/{installation_id}/access_tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app/installations/{installation_id}/access_tokens"]["response"];
+    };
+    deleteAuthorization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/grant"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/grant"]["response"];
+    };
+    deleteInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /app/installations/{installation_id}"]["response"];
+    };
+    deleteToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/token"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app"]["response"];
+    };
+    getBySlug: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /apps/{app_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /apps/{app_slug}"]["response"];
+    };
+    getInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations/{installation_id}"]["response"];
+    };
+    getOrgInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installation"]["response"];
+    };
+    getRepoInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/installation"]["response"];
+    };
+    getUserInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/installation"]["response"];
+    };
+    listInstallationReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations/{installation_id}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations/{installation_id}/repositories"]["response"];
+    };
+    listInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations"]["response"];
+    };
+    listInstallationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations"]["response"];
+    };
+    listReposAccessibleToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /installation/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /installation/repositories"]["response"];
+    };
+    removeRepoFromInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    resetToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /applications/{client_id}/token"]["response"];
+    };
+    revokeInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /installation/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /installation/token"]["response"];
+    };
+  };
+  checks: {
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-runs"]["response"];
+    };
+    createSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+    getSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["response"];
+    };
+    listAnnotations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["response"];
+    };
+    listForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["response"];
+    };
+    listForSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["response"];
+    };
+    listSuitesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["response"];
+    };
+    rerequestSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["response"];
+    };
+    setSuitesPreferences: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct"]["response"];
+    };
+    getConductCode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct/{key}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct/{key}"]["response"];
+    };
+  };
+  emojis: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /emojis"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /emojis"]["response"];
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/settings/authorized-keys"]["response"];
+    };
+    createEnterpriseServerLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/start"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/start"]["response"];
+    };
+    createGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks"]["response"];
+    };
+    createImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users/{username}/authorizations"]["response"];
+    };
+    createOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/organizations"]["response"];
+    };
+    createPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments"]["response"];
+    };
+    createPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-hooks"]["response"];
+    };
+    createUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users"]["response"];
+    };
+    deleteGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/hooks/{hook_id}"]["response"];
+    };
+    deleteImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}/authorizations"]["response"];
+    };
+    deletePersonalAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/tokens/{token_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/tokens/{token_id}"]["response"];
+    };
+    deletePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    deletePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    deletePublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/keys/{key_ids}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/keys/{key_ids}"]["response"];
+    };
+    deleteUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}"]["response"];
+    };
+    demoteSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/site_admin"]["response"];
+    };
+    enableOrDisableMaintenanceMode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/maintenance"]["response"];
+    };
+    getAllAuthorizedSshKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings/authorized-keys"]["response"];
+    };
+    getAllStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/gists"]["response"];
+    };
+    getCommentStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/comments"]["response"];
+    };
+    getConfigurationStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/configcheck"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/configcheck"]["response"];
+    };
+    getDownloadStatusForPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["response"];
+    };
+    getGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks/{hook_id}"]["response"];
+    };
+    getHooksStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/hooks"]["response"];
+    };
+    getIssueStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/issues"]["response"];
+    };
+    getLicenseInformation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/settings/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/settings/license"]["response"];
+    };
+    getMaintenanceStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/maintenance"]["response"];
+    };
+    getMilestoneStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/milestones"]["response"];
+    };
+    getOrgStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/orgs"]["response"];
+    };
+    getPagesStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pages"]["response"];
+    };
+    getPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    getPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPullRequestStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pulls"]["response"];
+    };
+    getRepoStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/repos"]["response"];
+    };
+    getSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings"]["response"];
+    };
+    getUserStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/users"]["response"];
+    };
+    listGlobalWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks"]["response"];
+    };
+    listPersonalAccessTokens: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/tokens"]["response"];
+    };
+    listPreReceiveEnvironments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments"]["response"];
+    };
+    listPreReceiveHooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["response"];
+    };
+    listPublicKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/keys"]["response"];
+    };
+    pingGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks/{hook_id}/pings"]["response"];
+    };
+    promoteUserToBeSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/site_admin"]["response"];
+    };
+    removeAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /setup/api/settings/authorized-keys"]["response"];
+    };
+    removePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    removePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    setSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /setup/api/settings"]["response"];
+    };
+    startConfigurationProcess: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/configure"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/configure"]["response"];
+    };
+    startPreReceiveEnvironmentDownload: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["response"];
+    };
+    suspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/suspended"]["response"];
+    };
+    syncLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["response"];
+    };
+    syncLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/users/{username}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/users/{username}/sync"]["response"];
+    };
+    unsuspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/suspended"]["response"];
+    };
+    updateGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/hooks/{hook_id}"]["response"];
+    };
+    updateLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["response"];
+    };
+    updateLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["response"];
+    };
+    updateOrgName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/organizations/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/organizations/{org}"]["response"];
+    };
+    updatePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    updatePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updateUsernameForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/users/{username}"]["response"];
+    };
+    upgradeLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/upgrade"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/upgrade"]["response"];
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/star"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/comments"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    fork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/forks"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    getRevision: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/{sha}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/commits"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gists"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/forks"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/public"]["response"];
+    };
+    listStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/starred"]["response"];
+    };
+    star: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /gists/{gist_id}/star"]["response"];
+    };
+    unstar: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/star"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+  };
+  git: {
+    createBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["response"];
+    };
+    createCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/commits"]["response"];
+    };
+    createRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/refs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/refs"]["response"];
+    };
+    createTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/tags"]["response"];
+    };
+    createTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/trees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/trees"]["response"];
+    };
+    deleteRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+    getBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["response"];
+    };
+    getRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["response"];
+    };
+    getTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["response"];
+    };
+    getTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["response"];
+    };
+    listMatchingRefs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["response"];
+    };
+    updateRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+  };
+  gitignore: {
+    getAllTemplates: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates"]["response"];
+    };
+    getTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates/{name}"]["response"];
+    };
+  };
+  issues: {
+    addAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    addLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    checkUserCanBeAssigned: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    createLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/labels"]["response"];
+    };
+    createMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    deleteLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    deleteMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    getEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["response"];
+    };
+    getLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    getMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /issues"]["response"];
+    };
+    listAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    listCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["response"];
+    };
+    listEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["response"];
+    };
+    listEventsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events"]["response"];
+    };
+    listEventsForTimeline: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/issues"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/issues"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
+    };
+    listLabelsForMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["response"];
+    };
+    listLabelsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels"]["response"];
+    };
+    listLabelsOnIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    listMilestones: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    lock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    removeAllLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    removeAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    removeLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["response"];
+    };
+    setLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    unlock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    updateLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    updateMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+  };
+  licenses: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses/{license}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses/{license}"]["response"];
+    };
+    getAllCommonlyUsed: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses"]["response"];
+    };
+    getForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/license"]["response"];
+    };
+  };
+  markdown: {
+    render: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown"]["response"];
+    };
+    renderRaw: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown/raw"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown/raw"]["response"];
+    };
+  };
+  meta: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /meta"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /meta"]["response"];
+    };
+    getOctocat: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /octocat"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /octocat"]["response"];
+    };
+    getZen: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /zen"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /zen"]["response"];
+    };
+    root: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /"]["response"];
+    };
+  };
+  orgs: {
+    checkMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members/{username}"]["response"];
+    };
+    checkPublicMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members/{username}"]["response"];
+    };
+    convertMemberToOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}"]["response"];
+    };
+    getMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs/{org}"]["response"];
+    };
+    getMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/memberships/{username}"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /organizations"]["response"];
+    };
+    listAppInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installations"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/orgs"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/orgs"]["response"];
+    };
+    listMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members"]["response"];
+    };
+    listMembershipsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs"]["response"];
+    };
+    listOutsideCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/outside_collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/outside_collaborators"]["response"];
+    };
+    listPublicMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeMember: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/members/{username}"]["response"];
+    };
+    removeMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/memberships/{username}"]["response"];
+    };
+    removeOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    removePublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/public_members/{username}"]["response"];
+    };
+    setMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/memberships/{username}"]["response"];
+    };
+    setPublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/public_members/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}"]["response"];
+    };
+    updateMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/memberships/orgs/{org}"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+  };
+  projects: {
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    createCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/cards"]["response"];
+    };
+    createColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/{project_id}/columns"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/projects"]["response"];
+    };
+    createForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/projects"]["response"];
+    };
+    createForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/projects"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}"]["response"];
+    };
+    deleteCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/cards/{card_id}"]["response"];
+    };
+    deleteColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/{column_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}"]["response"];
+    };
+    getCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/cards/{card_id}"]["response"];
+    };
+    getColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}"]["response"];
+    };
+    getPermissionForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["response"];
+    };
+    listCards: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}/cards"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators"]["response"];
+    };
+    listColumns: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/columns"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/projects"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/projects"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/projects"]["response"];
+    };
+    moveCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/cards/{card_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/cards/{card_id}/moves"]["response"];
+    };
+    moveColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/moves"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/{project_id}"]["response"];
+    };
+    updateCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/cards/{card_id}"]["response"];
+    };
+    updateColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/{column_id}"]["response"];
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    createReplyForReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["response"];
+    };
+    createReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    createReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    deletePendingReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    deleteReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    dismissReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    getReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    getReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    listCommentsForReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["response"];
+    };
+    listFiles: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["response"];
+    };
+    listRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    listReviewComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    listReviewCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["response"];
+    };
+    listReviews: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    removeRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    requestReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    submitReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    updateBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["response"];
+    };
+    updateReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    updateReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+  };
+  rateLimit: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /rate_limit"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /rate_limit"]["response"];
+    };
+  };
+  reactions: {
+    createForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    createForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    createForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    createForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    createForTeamDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    createForTeamDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["response"];
+    };
+    deleteForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForPullRequestComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForTeamDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForTeamDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteLegacy: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /reactions/{reaction_id}"]["response"];
+    };
+    listForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    listForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    listForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    listForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    listForTeamDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    listForTeamDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["response"];
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    addAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    addStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    addTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    addUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    checkCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    compareCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["response"];
+    };
+    compareCommitsWithBasehead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["response"];
+    };
+    createCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    createCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    createCommitStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["response"];
+    };
+    createDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/keys"]["response"];
+    };
+    createDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    createDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    createDispatchEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/dispatches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/dispatches"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/repos"]["response"];
+    };
+    createFork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/forks"]["response"];
+    };
+    createInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/repos"]["response"];
+    };
+    createOrUpdateFileContents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    createPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages"]["response"];
+    };
+    createRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/releases"]["response"];
+    };
+    createUsingTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    declineInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}"]["response"];
+    };
+    deleteAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    deleteAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    deleteBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    deleteCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    deleteCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    deleteDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    deleteDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    deleteFile: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    deleteInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    deletePagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pages"]["response"];
+    };
+    deletePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    deleteRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    deleteReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    downloadTarballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["response"];
+    };
+    downloadZipballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}"]["response"];
+    };
+    getAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    getAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    getAllStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    getAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/topics"]["response"];
+    };
+    getAppsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    getBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["response"];
+    };
+    getBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    getCodeFrequencyStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["response"];
+    };
+    getCollaboratorPermissionLevel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["response"];
+    };
+    getCombinedStatusForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["response"];
+    };
+    getCommitActivityStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["response"];
+    };
+    getCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    getCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    getContent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    getContributorsStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["response"];
+    };
+    getDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    getDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    getDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["response"];
+    };
+    getLatestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["response"];
+    };
+    getLatestRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["response"];
+    };
+    getPages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages"]["response"];
+    };
+    getPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["response"];
+    };
+    getParticipationStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["response"];
+    };
+    getPullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    getPunchCardStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["response"];
+    };
+    getReadme: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme"]["response"];
+    };
+    getReadmeInDirectory: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["response"];
+    };
+    getRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    getReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    getReleaseByTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["response"];
+    };
+    getStatusChecksProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    getTeamsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    getUsersWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    listBranches: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches"]["response"];
+    };
+    listBranchesForHeadCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators"]["response"];
+    };
+    listCommentsForCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    listCommitCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments"]["response"];
+    };
+    listCommitStatusesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits"]["response"];
+    };
+    listContributors: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contributors"]["response"];
+    };
+    listDeployKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys"]["response"];
+    };
+    listDeploymentStatuses: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    listDeployments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repos"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/repos"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/repos"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/forks"]["response"];
+    };
+    listInvitations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/invitations"]["response"];
+    };
+    listInvitationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repository_invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repository_invitations"]["response"];
+    };
+    listLanguages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/languages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/languages"]["response"];
+    };
+    listPagesBuilds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repositories"]["response"];
+    };
+    listPullRequestsAssociatedWithCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["response"];
+    };
+    listReleaseAssets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["response"];
+    };
+    listReleases: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases"]["response"];
+    };
+    listTags: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tags"]["response"];
+    };
+    listTeams: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/teams"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/merges"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/merges"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    removeStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    removeStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    removeTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    removeUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    replaceAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/topics"]["response"];
+    };
+    requestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    setAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    setAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    setStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    setTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    setUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    testPushWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["response"];
+    };
+    transfer: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/transfer"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/transfer"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}"]["response"];
+    };
+    updateBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    updateCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    updateInformationAboutPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pages"]["response"];
+    };
+    updateInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    updatePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    updateRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    updateReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    updateStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    uploadReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["response"];
+    };
+  };
+  search: {
+    code: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/code"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/code"]["response"];
+    };
+    commits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/commits"]["response"];
+    };
+    issuesAndPullRequests: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/issues"]["response"];
+    };
+    labels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/labels"]["response"];
+    };
+    repos: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/repositories"]["response"];
+    };
+    topics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/topics"]["response"];
+    };
+    users: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/users"]["response"];
+    };
+  };
+  teams: {
+    addOrUpdateMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    addOrUpdateProjectPermissionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    addOrUpdateRepoPermissionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    checkPermissionsForProjectInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    checkPermissionsForRepoInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams"]["response"];
+    };
+    createDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["response"];
+    };
+    createDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions"]["response"];
+    };
+    deleteDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    deleteDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    deleteInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getByName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    getDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    getMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams"]["response"];
+    };
+    listChildInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/teams"]["response"];
+    };
+    listDiscussionCommentsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["response"];
+    };
+    listDiscussionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/teams"]["response"];
+    };
+    listMembersInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["response"];
+    };
+    listProjectsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/projects"]["response"];
+    };
+    listReposInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/repos"]["response"];
+    };
+    removeMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    removeProjectInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    removeRepoInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    updateDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    updateDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    updateInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+  };
+  users: {
+    addEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/emails"]["response"];
+    };
+    checkFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following/{target_user}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following/{target_user}"]["response"];
+    };
+    checkPersonIsFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following/{username}"]["response"];
+    };
+    createGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/gpg_keys"]["response"];
+    };
+    createPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/keys"]["response"];
+    };
+    deleteEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/emails"]["response"];
+    };
+    deleteGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    deletePublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/keys/{key_id}"]["response"];
+    };
+    follow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/following/{username}"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user"]["response"];
+    };
+    getByUsername: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}"]["response"];
+    };
+    getContextForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/hovercard"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/hovercard"]["response"];
+    };
+    getGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    getPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys/{key_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users"]["response"];
+    };
+    listEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/emails"]["response"];
+    };
+    listFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following"]["response"];
+    };
+    listFollowersForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/followers"]["response"];
+    };
+    listFollowersForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/followers"]["response"];
+    };
+    listFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following"]["response"];
+    };
+    listGpgKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys"]["response"];
+    };
+    listGpgKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gpg_keys"]["response"];
+    };
+    listPublicEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/public_emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/public_emails"]["response"];
+    };
+    listPublicKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/keys"]["response"];
+    };
+    listPublicSshKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys"]["response"];
+    };
+    unfollow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/following/{username}"]["response"];
+    };
+    updateAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user"]["response"];
+    };
+  };
+};

--- a/src/generated/ghe-222-method-types.ts
+++ b/src/generated/ghe-222-method-types.ts
@@ -1,0 +1,7471 @@
+import { EndpointInterface, RequestInterface } from "@octokit/types";
+import { RestEndpointMethodTypes } from "./ghe-222-parameters-and-response-types";
+
+export type RestEndpointMethods = {
+  actions: {
+    /**
+     * Adds a repository to an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@2.22/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    addSelectedRepoToOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["addSelectedRepoToOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["addSelectedRepoToOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Cancels a workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    cancelWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["cancelWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["cancelWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates an organization secret with an encrypted value. Encrypt your secret using
+     * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
+     * token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to
+     * use this endpoint.
+     *
+     * #### Example encrypting a secret using Node.js
+     *
+     * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
+     *
+     * ```
+     * const sodium = require('tweetsodium');
+     *
+     * const key = "base64-encoded-public-key";
+     * const value = "plain-text-secret";
+     *
+     * // Convert the message and key to Uint8Array's (Buffer implements that interface)
+     * const messageBytes = Buffer.from(value);
+     * const keyBytes = Buffer.from(key, 'base64');
+     *
+     * // Encrypt using LibSodium.
+     * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+     *
+     * // Base64 the encrypted secret
+     * const encrypted = Buffer.from(encryptedBytes).toString('base64');
+     *
+     * console.log(encrypted);
+     * ```
+     *
+     *
+     * #### Example encrypting a secret using Python
+     *
+     * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
+     *
+     * ```
+     * from base64 import b64encode
+     * from nacl import encoding, public
+     *
+     * def encrypt(public_key: str, secret_value: str) -> str:
+     *   """Encrypt a Unicode string using the public key."""
+     *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+     *   sealed_box = public.SealedBox(public_key)
+     *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+     *   return b64encode(encrypted).decode("utf-8")
+     * ```
+     *
+     * #### Example encrypting a secret using C#
+     *
+     * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
+     *
+     * ```
+     * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
+     * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
+     *
+     * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+     *
+     * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+     * ```
+     *
+     * #### Example encrypting a secret using Ruby
+     *
+     * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
+     *
+     * ```ruby
+     * require "rbnacl"
+     * require "base64"
+     *
+     * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
+     * public_key = RbNaCl::PublicKey.new(key)
+     *
+     * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+     * encrypted_secret = box.encrypt("my_secret")
+     *
+     * # Print the base64 encoded secret
+     * puts Base64.strict_encode64(encrypted_secret)
+     * ```
+     */
+    createOrUpdateOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createOrUpdateOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createOrUpdateOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates a repository secret with an encrypted value. Encrypt your secret using
+     * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
+     * token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use
+     * this endpoint.
+     *
+     * #### Example encrypting a secret using Node.js
+     *
+     * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
+     *
+     * ```
+     * const sodium = require('tweetsodium');
+     *
+     * const key = "base64-encoded-public-key";
+     * const value = "plain-text-secret";
+     *
+     * // Convert the message and key to Uint8Array's (Buffer implements that interface)
+     * const messageBytes = Buffer.from(value);
+     * const keyBytes = Buffer.from(key, 'base64');
+     *
+     * // Encrypt using LibSodium.
+     * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+     *
+     * // Base64 the encrypted secret
+     * const encrypted = Buffer.from(encryptedBytes).toString('base64');
+     *
+     * console.log(encrypted);
+     * ```
+     *
+     *
+     * #### Example encrypting a secret using Python
+     *
+     * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
+     *
+     * ```
+     * from base64 import b64encode
+     * from nacl import encoding, public
+     *
+     * def encrypt(public_key: str, secret_value: str) -> str:
+     *   """Encrypt a Unicode string using the public key."""
+     *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+     *   sealed_box = public.SealedBox(public_key)
+     *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+     *   return b64encode(encrypted).decode("utf-8")
+     * ```
+     *
+     * #### Example encrypting a secret using C#
+     *
+     * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
+     *
+     * ```
+     * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
+     * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
+     *
+     * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+     *
+     * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+     * ```
+     *
+     * #### Example encrypting a secret using Ruby
+     *
+     * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
+     *
+     * ```ruby
+     * require "rbnacl"
+     * require "base64"
+     *
+     * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
+     * public_key = RbNaCl::PublicKey.new(key)
+     *
+     * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+     * encrypted_secret = box.encrypt("my_secret")
+     *
+     * # Print the base64 encoded secret
+     * puts Base64.strict_encode64(encrypted_secret)
+     * ```
+     */
+    createOrUpdateRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createOrUpdateRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createOrUpdateRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script. The token expires after one hour.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     *
+     * #### Example using registration token
+     *
+     * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh --url https://github.com/octo-org --token TOKEN
+     * ```
+     */
+    createRegistrationTokenForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRegistrationTokenForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRegistrationTokenForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script. The token expires after one hour. You must authenticate
+     * using an access token with the `repo` scope to use this endpoint.
+     *
+     * #### Example using registration token
+     *
+     * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh --url https://github.com/octo-org/octo-repo-artifacts --token TOKEN
+     * ```
+     */
+    createRegistrationTokenForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRegistrationTokenForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRegistrationTokenForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script to remove a self-hosted runner from an organization. The token expires after one hour.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     *
+     * #### Example using remove token
+     *
+     * To remove your self-hosted runner from an organization, replace `TOKEN` with the remove token provided by this
+     * endpoint.
+     *
+     * ```
+     * ./config.sh remove --token TOKEN
+     * ```
+     */
+    createRemoveTokenForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRemoveTokenForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRemoveTokenForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to remove a self-hosted runner from a repository. The token expires after one hour.
+     * You must authenticate using an access token with the `repo` scope to use this endpoint.
+     *
+     * #### Example using remove token
+     *
+     * To remove your self-hosted runner from a repository, replace TOKEN with the remove token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh remove --token TOKEN
+     * ```
+     */
+    createRemoveTokenForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRemoveTokenForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRemoveTokenForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to manually trigger a GitHub Actions workflow run. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must configure your GitHub Actions workflow to run when the [`workflow_dispatch` webhook](/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch) event occurs. The `inputs` are configured in the workflow file. For more information about how to configure the `workflow_dispatch` event in the workflow file, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#workflow_dispatch)."
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)."
+     */
+    createWorkflowDispatch: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes an artifact for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    deleteArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteArtifact"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteArtifact"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a secret in an organization using the secret name. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    deleteOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a secret in a repository using the secret name. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    deleteRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Forces the removal of a self-hosted runner from an organization. You can use this endpoint to completely remove the runner when the machine you were using no longer exists.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    deleteSelfHostedRunnerFromOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Forces the removal of a self-hosted runner from a repository. You can use this endpoint to completely remove the runner when the machine you were using no longer exists.
+     *
+     * You must authenticate using an access token with the `repo`
+     * scope to use this endpoint.
+     */
+    deleteSelfHostedRunnerFromRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a specific workflow run. Anyone with write access to the repository can use this endpoint. If the repository is
+     * private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:write` permission to use
+     * this endpoint.
+     */
+    deleteWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes all logs for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    deleteWorkflowRunLogs: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteWorkflowRunLogs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteWorkflowRunLogs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download an archive for a repository. This URL expires after 1 minute. Look for `Location:` in
+     * the response header to find the URL for the download. The `:archive_format` must be `zip`. Anyone with read access to
+     * the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+     * GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    downloadArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadArtifact"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadArtifact"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a plain text file of logs for a workflow job. This link expires after 1 minute. Look
+     * for `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can
+     * use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must
+     * have the `actions:read` permission to use this endpoint.
+     */
+    downloadJobLogsForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadJobLogsForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadJobLogsForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download an archive of log files for a workflow run. This link expires after 1 minute. Look for
+     * `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can use
+     * this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have
+     * the `actions:read` permission to use this endpoint.
+     */
+    downloadWorkflowRunLogs: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadWorkflowRunLogs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadWorkflowRunLogs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific artifact for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getArtifact"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["actions"]["getArtifact"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific job in a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getJobForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getJobForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getJobForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    getOrgPublicKey: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getOrgPublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getOrgPublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a single organization secret without revealing its encrypted value. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    getOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    getRepoPublicKey: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getRepoPublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getRepoPublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a single repository secret without revealing its encrypted value. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    getRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific self-hosted runner configured in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    getSelfHostedRunnerForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific self-hosted runner configured in a repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint.
+     */
+    getSelfHostedRunnerForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific workflow. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getWorkflow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["actions"]["getWorkflow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all artifacts for a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listArtifactsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listArtifactsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listArtifactsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists jobs for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#parameters).
+     */
+    listJobsForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all secrets available in an organization without revealing their encrypted values. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    listOrgSecrets: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listOrgSecrets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listOrgSecrets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all secrets available in a repository without revealing their encrypted values. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    listRepoSecrets: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRepoSecrets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRepoSecrets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the workflows in a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listRepoWorkflows: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists binaries for the runner application that you can download and run.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    listRunnerApplicationsForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRunnerApplicationsForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRunnerApplicationsForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists binaries for the runner application that you can download and run.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint.
+     */
+    listRunnerApplicationsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRunnerApplicationsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRunnerApplicationsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all repositories that have been selected when the `visibility` for repository access to a secret is set to `selected`. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    listSelectedReposForOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelectedReposForOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelectedReposForOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all self-hosted runners configured in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    listSelfHostedRunnersForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all self-hosted runners configured in a repository. You must authenticate using an access token with the `repo` scope to use this endpoint.
+     */
+    listSelfHostedRunnersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists artifacts for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listWorkflowRunArtifacts: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRunArtifacts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRunArtifacts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all workflow runs for a workflow. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#parameters).
+     *
+     * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+     */
+    listWorkflowRuns: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRuns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRuns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all workflow runs for a repository. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#parameters).
+     *
+     * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listWorkflowRunsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Re-runs your workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    reRunWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["reRunWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["reRunWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a repository from an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@2.22/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    removeSelectedRepoFromOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["removeSelectedRepoFromOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["removeSelectedRepoFromOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces all repositories for an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@2.22/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    setSelectedReposForOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setSelectedReposForOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setSelectedReposForOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#set-a-repository-subscription).
+     */
+    deleteRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Mutes all future notifications for a conversation until you comment on the thread or get an **@mention**. If you are watching the repository of the thread, you will still receive notifications. To ignore future notifications for a repository you are watching, use the [Set a thread subscription](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#set-a-thread-subscription) endpoint and set `ignore` to `true`.
+     */
+    deleteThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * GitHub Enterprise Server provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:
+     *
+     * *   **Timeline**: The GitHub Enterprise Server global public timeline
+     * *   **User**: The public timeline for any user, using [URI template](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#hypermedia)
+     * *   **Current user public**: The public timeline for the authenticated user
+     * *   **Current user**: The private timeline for the authenticated user
+     * *   **Current user actor**: The private timeline for activity created by the authenticated user
+     * *   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
+     * *   **Security advisories**: A collection of public announcements that provide information about security-related vulnerabilities in software on GitHub Enterprise Server.
+     *
+     * **Note**: Private feeds are only returned when [authenticating via Basic Auth](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication) since current feed URIs use the older, non revocable auth tokens.
+     */
+    getFeeds: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getFeeds"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getFeeds"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getThread: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThread"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getThread"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This checks to see if the current user is subscribed to a thread. You can also [get a repository subscription](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#get-a-repository-subscription).
+     *
+     * Note that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mentioned**, or manually subscribe to a thread.
+     */
+    getThreadSubscriptionForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+     */
+    listEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user, sorted by most recently updated.
+     */
+    listNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This is the user's organization dashboard. You must be authenticated as the user to view this.
+     */
+    listOrgEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * We delay the public events feed by five minutes, which means the most recent event returned by the public events API actually occurred at least five minutes ago.
+     */
+    listPublicEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForRepoNetwork: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicOrgEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.
+     */
+    listReceivedEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReceivedPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRepoEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user.
+     */
+    listRepoNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user is watching.
+     */
+    listReposWatchedByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people that have starred the repository.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/) via the `Accept` header:
+     */
+    listStargazersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user is watching.
+     */
+    listWatchedReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people watching the specified repository.
+     */
+    listWatchersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications as "read" removes it from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List notifications for the authenticated user](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#list-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications in a repository as "read" removes them from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List repository notifications for the authenticated user](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#list-repository-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markRepoNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    markThreadAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markThreadAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markThreadAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#delete-a-repository-subscription) completely.
+     */
+    setRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are watching a repository, you receive notifications for all threads by default. Use this endpoint to ignore future notifications for threads until you comment on the thread or get an **@mention**.
+     *
+     * You can also use this endpoint to subscribe to threads that you are currently not receiving notifications for or to subscribed to threads that you have previously ignored.
+     *
+     * Unsubscribing from a conversation in a repository that you are not watching is functionally equivalent to the [Delete a thread subscription](https://docs.github.com/enterprise-server@2.22/rest/reference/activity#delete-a-thread-subscription) endpoint.
+     */
+    setThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    starRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstarRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  apps: {
+    /**
+     * Add a single repository to an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@2.22/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    addRepoToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication) to use this endpoint, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.
+     */
+    checkToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["checkToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["checkToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated:** use `apps.createContentAttachmentForRepo()` (`POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments`) instead. Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://docs.github.com/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachment: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` and `repository` `full_name` of the content reference from the [`content_reference` event](https://docs.github.com/enterprise-server@2.22/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/enterprise-server@2.22/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachmentForRepo: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.
+     */
+    createFromManifest: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createFromManifest"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createFromManifest"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an installation access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token. By default the installation token has access to all repositories that the installation can access. To restrict the access to specific repositories, you can provide the `repository_ids` when creating the token. When you omit `repository_ids`, the response does not contain the `repositories` key.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    createInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid OAuth `access_token` as an input parameter and the grant for the token's owner will be deleted.
+     * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+     */
+    deleteAuthorization: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteAuthorization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteAuthorization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uninstalls a GitHub App on a user, organization, or business account. If you prefer to temporarily suspend an app's access to your account's resources, then we recommend the "[Suspend an app installation](https://docs.github.com/enterprise-server@2.22/rest/reference/apps/#suspend-an-app-installation)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    deleteInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+     */
+    deleteToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["deleteToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the "[List installations for the authenticated app](https://docs.github.com/enterprise-server@2.22/rest/reference/apps#list-installations-for-the-authenticated-app)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).
+     *
+     * If the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    getBySlug: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getBySlug"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["getBySlug"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find an installation's information using the installation id. The installation's account type (`target_type`) will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the organization's installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getOrgInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getOrgInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getOrgInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getRepoInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getRepoInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getRepoInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the user’s installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getUserInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getUserInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getUserInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The access the user has to each repository is included in the hash under the `permissions` key.
+     */
+    listInstallationReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     *
+     * The permissions the installation has are included under the `permissions` key.
+     */
+    listInstallations: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You can find the permissions for the installation under the `permissions` key.
+     */
+    listInstallationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that an app installation can access.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    listReposAccessibleToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Remove a single repository from an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@2.22/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    removeRepoFromInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    resetToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["resetToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["resetToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Revokes the installation token you're using to authenticate as an installation and access this endpoint.
+     *
+     * Once an installation token is revoked, the token is invalidated and cannot be used. Other endpoints that require the revoked installation token must have a new installation token to work. You can create a new token using the "[Create an installation access token for an app](https://docs.github.com/enterprise-server@2.22/rest/reference/apps#create-an-installation-access-token-for-an-app)" endpoint.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    revokeInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Suspends a GitHub App on a user, organization, or business account, which blocks the app from accessing the account's resources. When a GitHub App is suspended, the app's access to the GitHub Enterprise Server API or webhook events is blocked for that account.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    suspendInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["suspendInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["suspendInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GitHub App installation suspension.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    unsuspendInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["unsuspendInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["unsuspendInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  checks: {
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Creates a new check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to create check runs.
+     *
+     * In a check suite, GitHub limits the number of check runs with the same name to 1000. Once these check runs exceed 1000, GitHub will start to automatically delete older check runs.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * By default, check suites are automatically created when you create a [check run](https://docs.github.com/enterprise-server@2.22/rest/reference/checks#check-runs). You only need to use this endpoint for manually creating check suites when you've disabled automatic creation using "[Update repository preferences for check suites](https://docs.github.com/enterprise-server@2.22/rest/reference/checks#update-repository-preferences-for-check-suites)". Your GitHub App must have the `checks:write` permission to create check suites.
+     */
+    createSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["createSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["createSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    getSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["getSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["getSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.
+     */
+    listAnnotations: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listAnnotations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listAnnotations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    listSuitesForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listSuitesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listSuitesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository. This endpoint will trigger the [`check_suite` webhook](https://docs.github.com/enterprise-server@2.22/webhooks/event-payloads/#check_suite) event with the action `rerequested`. When a check suite is `rerequested`, its `status` is reset to `queued` and the `conclusion` is cleared.
+     *
+     * To rerequest a check suite, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.
+     */
+    rerequestSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["rerequestSuite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["rerequestSuite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://docs.github.com/enterprise-server@2.22/rest/reference/checks#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.
+     */
+    setSuitesPreferences: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Updates a check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to edit check runs.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codeScanning: {
+    /**
+     * Gets a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` read permission to use this endpoint.
+     *
+     * **Deprecation notice**:
+     * The instances field is deprecated and will, in future, not be included in the response for this endpoint. From GitHub Enterprise Server 3.0, the same information can be retrieved via a GET request to the URL specified by `instances_url`, added in that release.
+     */
+    getAlert: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["getAlert"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["getAlert"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all open code scanning alerts for the default branch (usually `main`
+     * or `master`). You must use an access token with the `security_events` scope to use
+     * this endpoint. GitHub Apps must have the `security_events` read permission to use
+     * this endpoint.
+     */
+    listAlertsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["listAlertsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["listAlertsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the details of all code scanning analyses for a repository,
+     * starting with the most recent.
+     * The response is paginated and you can use the `page` and `per_page` parameters
+     * to list the analyses you're interested in.
+     * By default 30 analyses are listed per page.
+     *
+     * The `rules_count` field in the response give the number of rules
+     * that were run in the analysis.
+     * For very old analyses this data is not available,
+     * and `0` is returned in this field.
+     *
+     * You must use an access token with the `security_events` scope to use this endpoint.
+     * GitHub Apps must have the `security_events` read permission to use this endpoint.
+     *
+     * **Deprecation notice**:
+     * The `tool_name` field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The tool name can now be found inside the `tool` field.
+     */
+    listRecentAnalyses: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["listRecentAnalyses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["listRecentAnalyses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the status of a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` write permission to use this endpoint.
+     */
+    updateAlert: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["updateAlert"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["updateAlert"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uploads SARIF data containing the results of a code scanning analysis to make the results available in a repository. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` write permission to use this endpoint.
+     *
+     * There are two places where you can upload code scanning results.
+     *  - If you upload to a pull request, for example `--ref refs/pull/42/merge` or `--ref refs/pull/42/head`, then the results appear as alerts in a pull request check. For more information, see "[Triaging code scanning alerts in pull requests](/github/finding-security-vulnerabilities-and-errors-in-your-code/automatically-scanning-your-code-for-vulnerabilities-and-errors/triaging-code-scanning-alerts-in-pull-requests)."
+     *  - If you upload to a branch, for example `--ref refs/heads/my-branch`, then the results appear in the **Security** tab for your repository. For more information, see "[Managing code scanning alerts for your repository](/github/finding-security-vulnerabilities-and-errors-in-your-code/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#viewing-the-alerts-for-a-repository)."
+     *
+     * You must compress the SARIF-formatted analysis data that you want to upload, using `gzip`, and then encode it as a Base64 format string. For example:
+     *
+     * ```
+     * gzip -c analysis-data.sarif | base64 -w0
+     * ```
+     *
+     * SARIF upload supports a maximum of 1000 results per analysis run. Any results over this limit are ignored. Typically, but not necessarily, a SARIF file contains a single run of a single tool. If a code scanning tool generates too many results, you should update the analysis configuration to run only the most important rules or queries.
+     *
+     * The `202 Accepted`, response includes an `id` value.
+     * You can use this ID to check the status of the upload by using this for the `/sarifs/{sarif_id}` endpoint.
+     * For more information, see "[Get information about a SARIF upload](/rest/reference/code-scanning#get-information-about-a-sarif-upload)."
+     */
+    uploadSarif: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["uploadSarif"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["uploadSarif"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getConductCode: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  emojis: {
+    /**
+     * Lists all the emojis available to use on GitHub Enterprise Server.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["emojis"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["emojis"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you boot a GitHub instance for the first time, you can use the following endpoint to upload a license:
+     *
+     * Note that you need to POST to [`/setup/api/configure`](https://docs.github.com/enterprise-server@2.22/rest/reference/enterprise-admin#start-a-configuration-process) to start the actual configuration process.
+     *
+     * When using this endpoint, your GitHub instance must have a password set. This can be accomplished two ways:
+     *
+     * 1.  If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
+     * 2.  If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
+     *
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@2.22/rest/reference/enterprise-admin#get-settings).
+     */
+    createEnterpriseServerLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If an external authentication mechanism is used, the login name should match the login name in the external system. If you are using LDAP authentication, you should also [update the LDAP mapping](https://docs.github.com/enterprise-server@2.22/rest/reference/enterprise-admin#update-ldap-mapping-for-a-user) for the user.
+     *
+     * The login name will be normalized to only contain alphanumeric characters or single hyphens. For example, if you send `"octo_cat"` as the login, a user named `"octo-cat"` will be created.
+     *
+     * If the login name or email address is already associated with an account, the server will return a `422` response.
+     */
+    createUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a personal access token. Returns a `403 - Forbidden` status when a personal access token is in use. For example, if you access this endpoint with the same personal access token that you are trying to delete, you will receive this error.
+     */
+    deletePersonalAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you attempt to delete an environment that cannot be deleted, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * *   _Cannot modify or delete the default environment_
+     * *   _Cannot delete environment that has hooks_
+     * *   _Cannot delete environment when download is in progress_
+     */
+    deletePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePublicKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a user will delete all their repositories, gists, applications, and personal settings. [Suspending a user](https://docs.github.com/enterprise-server@2.22/rest/reference/enterprise-admin#suspend-a-user) is often a better option.
+     *
+     * You can delete any user account except your own.
+     */
+    deleteUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can demote any user account except your own.
+     */
+    demoteSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The possible values for `enabled` are `true` and `false`. When it's `false`, the attribute `when` is ignored and the maintenance mode is turned off. `when` defines the time period when the maintenance was enabled.
+     *
+     * The possible values for `when` are `now` or any date parseable by [mojombo/chronic](https://github.com/mojombo/chronic).
+     */
+    enableOrDisableMaintenanceMode: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllAuthorizedSshKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommentStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to check the status of the most recent configuration process:
+     *
+     * Note that you may need to wait several seconds after you start a process before you can check its status.
+     *
+     * The different statuses are:
+     *
+     * | Status        | Description                       |
+     * | ------------- | --------------------------------- |
+     * | `PENDING`     | The job has not started yet       |
+     * | `CONFIGURING` | The job is running                |
+     * | `DONE`        | The job has finished correctly    |
+     * | `FAILED`      | The job has finished unexpectedly |
+     */
+    getConfigurationStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In addition to seeing the download status at the "[Get a pre-receive environment](#get-a-pre-receive-environment)" endpoint, there is also this separate endpoint for just the download status.
+     */
+    getDownloadStatusForPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getHooksStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getIssueStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLicenseInformation: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Check your installation's maintenance status:
+     */
+    getMaintenanceStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestoneStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getOrgStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPullRequestStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getUserStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listGlobalWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists personal access tokens for all users, including admin users.
+     */
+    listPersonalAccessTokens: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveEnvironments: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveHooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this organization as well as any disabled hooks that can be configured at the organization level. Globally disabled pre-receive hooks that do not allow downstream configuration are not listed.
+     */
+    listPreReceiveHooksForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this repository as well as any disabled hooks that are allowed to be enabled at the repository level. Pre-receive hooks that are disabled at a higher level and are not configurable will not be listed.
+     */
+    listPreReceiveHooksForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.22/webhooks/#ping-event) to be sent to the webhook.
+     */
+    pingGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    promoteUserToBeSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any overrides for this hook at the org level for this org.
+     */
+    removePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes any overridden enforcement on this repository for the specified hook.
+     *
+     * Responds with effective values inherited from owner and/or global level.
+     */
+    removePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@2.22/rest/reference/enterprise-admin#get-settings).
+     */
+    setSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to start a configuration process at any time for your updated settings to take effect:
+     */
+    startConfigurationProcess: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers a new download of the environment tarball from the environment's `image_url`. When the download is finished, the newly downloaded tarball will overwrite the existing environment.
+     *
+     * If a download cannot be triggered, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * * _Cannot modify or delete the default environment_
+     * * _Can not start a new download when a download is in progress_
+     */
+    startPreReceiveEnvironmentDownload: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), Active Directory LDAP-authenticated users cannot be suspended through this API. If you attempt to suspend an Active Directory LDAP-authenticated user through this API, it will return a `403` response.
+     *
+     * You can suspend any user account except your own.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    suspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), this API is disabled and will return a `403` response. Active Directory LDAP-authenticated users cannot be unsuspended using the API.
+     */
+    unsuspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Parameters that are not provided will be overwritten with the default value or removed if no default exists.
+     */
+    updateGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the [distinguished name](https://www.ldap.com/ldap-dns-and-rdns) (DN) of the LDAP entry to map to a team. [LDAP synchronization](https://help.github.com/enterprise/admin/guides/user-management/using-ldap/#enabling-ldap-sync) must be enabled to map LDAP entries to a team. Use the [Create a team](https://docs.github.com/enterprise-server@2.22/rest/reference/teams/#create-a-team) endpoint to create a team with LDAP mapping.
+     *
+     * If you pass the `hellcat-preview` media type, you can also update the LDAP mapping of a child team.
+     */
+    updateLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateOrgName: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You cannot modify the default environment. If you attempt to modify the default environment, you will receive a `422 Unprocessable Entity` response.
+     */
+    updatePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updatePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the org level, you can set `enforcement` and `allow_downstream_configuration`
+     */
+    updatePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the repo level, you can set `enforcement`
+     */
+    updatePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateUsernameForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This API upgrades your license and also triggers the configuration process:
+     */
+    upgradeLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["checkIsStarred"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gists"]["checkIsStarred"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to add a new gist with one or more files.
+     *
+     * **Note:** Don't name your files "gistfile" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["createComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["createComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["deleteComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["deleteComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: This was previously `/gists/:gist_id/fork`.
+     */
+    fork: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["fork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["fork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    get: {
+      (params?: RestEndpointMethodTypes["gists"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["gists"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRevision: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getRevision"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getRevision"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the authenticated user's gists or if called anonymously, this endpoint returns all public gists:
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public gists for the specified user:
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List public gists sorted by most recently updated to least recently updated.
+     *
+     * Note: With [pagination](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the authenticated user's starred gists:
+     */
+    listStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listStarred"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listStarred"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    star: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["star"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["star"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstar: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["unstar"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["unstar"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to update or delete a gist file and rename gist files. Files from the previous version of the gist that aren't explicitly changed during an edit are unchanged.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["updateComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["updateComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  git: {
+    createBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reference for your repository. You are unable to create new references for empty repositories, even if the commit SHA-1 hash used exists. Empty repositories are repositories without branches.
+     */
+    createRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://docs.github.com/enterprise-server@2.22/rest/reference/git#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://docs.github.com/enterprise-server@2.22/rest/reference/git#create-a-reference) the tag reference - this call would be unnecessary.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The tree creation API accepts nested entries. If you specify both a tree and a nested path modifying that tree, this endpoint will overwrite the contents of the tree with the new path contents, and create a new tree structure.
+     *
+     * If you use this endpoint to add, delete, or modify the file contents in a tree, you will need to commit the tree and then update a branch to point to the commit. For more information see "[Create a commit](https://docs.github.com/enterprise-server@2.22/rest/reference/git#create-a-commit)" and "[Update a reference](https://docs.github.com/enterprise-server@2.22/rest/reference/git#update-a-reference)."
+     */
+    createTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["deleteRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["deleteRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `content` in the response will always be Base64 encoded.
+     *
+     * _Note_: This API supports blobs up to 100 megabytes in size.
+     */
+    getBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single reference from your Git database. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't match an existing ref, a `404` is returned.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.22/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     */
+    getRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single tree using the SHA1 value for that tree.
+     *
+     * If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+     */
+    getTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns an array of references from your Git database that match the supplied name. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't exist in the repository, but existing refs start with `:ref`, they will be returned as an array.
+     *
+     * When you use this endpoint without providing a `:ref`, it will return an array of all the references from your Git database, including notes and stashes if they exist on the server. Anything in the namespace is returned, not just `heads` and `tags`.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.22/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * If you request matching references for a branch named `feature` but the branch `feature` doesn't exist, the response can still include other matching head refs that start with the word `feature`, such as `featureA` and `featureB`.
+     */
+    listMatchingRefs: {
+      (
+        params?: RestEndpointMethodTypes["git"]["listMatchingRefs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["git"]["listMatchingRefs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["updateRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["updateRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gitignore: {
+    /**
+     * List all templates available to pass as an option when [creating a repository](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#create-a-repository-for-the-authenticated-user).
+     */
+    getAllTemplates: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API also allows fetching the source of a single template.
+     * Use the raw [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/) to get the raw contents.
+     */
+    getTemplate: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  issues: {
+    /**
+     * Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.
+     */
+    addAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addAssignees"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addAssignees"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    addLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks if a user has permission to be assigned to an issue in this repository.
+     *
+     * If the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.
+     *
+     * Otherwise a `404` status code is returned.
+     */
+    checkUserCanBeAssigned: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://help.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["createLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["deleteLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API returns a [`301 Moved Permanently` status](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-redirects-redirects) if the issue was
+     * [transferred](https://help.github.com/articles/transferring-an-issue-to-another-repository/) to another repository. If
+     * the issue was transferred to or deleted from a repository where the authenticated user lacks read access, the API
+     * returns a `404 Not Found` status. If the issue was deleted from a repository where the authenticated user has read
+     * access, the API returns a `410 Gone` status. To receive webhook events for transferred and deleted issues, subscribe
+     * to the [`issues`](https://docs.github.com/enterprise-server@2.22/webhooks/event-payloads/#issues) webhook.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getEvent: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getEvent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getEvent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getMilestone"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getMilestone"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues assigned to the authenticated user across all visible repositories including owned repositories, member
+     * repositories, and organization repositories. You can use the `filter` query parameter to fetch issues that are not
+     * necessarily assigned to you.
+     *
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.
+     */
+    listAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue Comments are ordered by ascending ID.
+     */
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * By default, Issue Comments are ordered by ascending ID.
+     */
+    listCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEvents: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEvents"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listEvents"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForTimeline: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues across owned and member repositories assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in an organization assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in a repository.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsOnIssue: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMilestones: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listMilestones"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listMilestones"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can lock an issue or pull request's conversation.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    lock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["lock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["lock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAllLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAllLabels"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAllLabels"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes one or more assignees from an issue.
+     */
+    removeAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the specified label from the issue, and returns the remaining labels on the issue. This endpoint returns a `404 Not Found` status if the label does not exist.
+     */
+    removeLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["removeLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any previous labels and sets the new labels for an issue.
+     */
+    setLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["setLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["setLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can unlock an issue's conversation.
+     */
+    unlock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["unlock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["unlock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue owners and users with push access can edit an issue.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  licenses: {
+    get: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllCommonlyUsed: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This method returns the contents of the repository's license file, if one is detected.
+     *
+     * Similar to [Get repository content](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#get-repository-content), this method also supports [custom media types](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types) for retrieving the raw license content or rendered license HTML.
+     */
+    getForRepo: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["getForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  markdown: {
+    render: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["render"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["render"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.
+     */
+    renderRaw: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["renderRaw"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["renderRaw"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  meta: {
+    get: {
+      (params?: RestEndpointMethodTypes["meta"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get the octocat as ASCII art
+     */
+    getOctocat: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getOctocat"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getOctocat"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a random sentence from the Zen of GitHub
+     */
+    getZen: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getZen"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getZen"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get Hypermedia links to resources accessible in GitHub's REST API
+     */
+    root: {
+      (params?: RestEndpointMethodTypes["meta"]["root"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["root"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  orgs: {
+    /**
+     * Check if a user is, publicly or privately, a member of the organization.
+     */
+    checkMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPublicMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see "[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)".
+     */
+    convertMemberToOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Here's how you can create a hook that posts payloads in JSON format:
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
+     *
+     * GitHub Apps with the `Organization plan` permission can use this endpoint to retrieve information about an organization's GitHub Enterprise Server plan. See "[Authenticating with GitHub Apps](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/authenticating-with-github-apps/)" for details. For an example response, see 'Response with GitHub Enterprise Server plan information' below."
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["orgs"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to get a user's membership with an organization, the authenticated user must be an organization member. The `state` parameter in the response can be used to identify the user's membership status.
+     */
+    getMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in an organization. To get only the webhook `config` properties, see "[Get a webhook configuration for an organization](/rest/reference/orgs#get-a-webhook-configuration-for-an-organization)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all organizations, in the order that they were created on GitHub Enterprise Server.
+     *
+     * **Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of organizations.
+     */
+    list: {
+      (params?: RestEndpointMethodTypes["orgs"]["list"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["list"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all GitHub Apps in an organization. The installation count includes all GitHub Apps installed on repositories in the organization. You must be an organization owner with `admin:read` scope to use this endpoint.
+     */
+    listAppInstallations: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listAppInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listAppInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List organizations for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * This only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.
+     *
+     * This method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List organizations for the authenticated user](https://docs.github.com/enterprise-server@2.22/rest/reference/orgs#list-organizations-for-the-authenticated-user) API instead.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
+     */
+    listMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembers"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listMembers"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMembershipsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are outside collaborators of an organization.
+     */
+    listOutsideCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Members of an organization can choose to have their membership publicized or not.
+     */
+    listPublicMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listPublicMembers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listPublicMembers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.22/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+     */
+    removeMember: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMember"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["removeMember"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to remove a user's membership with an organization, the authenticated user must be an organization owner.
+     *
+     * If the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.
+     */
+    removeMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all the organization's repositories.
+     */
+    removeOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removePublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Only authenticated organization owners can add a member to the organization or update the member's role.
+     *
+     * *   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](https://docs.github.com/enterprise-server@2.22/rest/reference/orgs#get-organization-membership-for-a-user) will be `pending` until they accept the invitation.
+     *
+     * *   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.
+     */
+    setMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The user can publicize their own membership. (A user cannot publicize the membership for another user.)
+     *
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    setPublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Parameter Deprecation Notice:** GitHub Enterprise Server will replace and discontinue `members_allowed_repository_creation_type` in favor of more granular permissions. The new input parameters are `members_can_create_public_repositories`, `members_can_create_private_repositories` for all organizations and `members_can_create_internal_repositories` for organizations associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. For more information, see the [blog post](https://developer.github.com/changes/2019-12-03-internal-visibility-changes).
+     *
+     * Enables an authenticated organization owner with the `admin:org` scope to update the organization's profile and member privileges.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in an organization. When you update a webhook, the `secret` will be overwritten. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for an organization](/rest/reference/orgs#update-a-webhook-configuration-for-an-organization)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  projects: {
+    /**
+     * Adds a collaborator to an organization project and sets their permission level. You must be an organization owner or a project `admin` to add a collaborator.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["createCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an organization project board. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a repository project board. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a project board. Returns a `404 Not Found` status if projects are disabled.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["deleteCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["deleteColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a project by its `id`. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the collaborator's permission level for an organization project. Possible values for the `permission` key: `admin`, `write`, `read`, `none`. You must be an organization owner or a project `admin` to review a user's permission level.
+     */
+    getPermissionForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getPermissionForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["getPermissionForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCards: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCards"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listCards"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listColumns: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listColumns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listColumns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a collaborator from an organization project. You must be an organization owner or a project `admin` to remove a collaborator.
+     */
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a project board's information. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["updateCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["updateColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["checkIfMerged"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["checkIfMerged"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+     *
+     * You can create a new pull request.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reply to a review comment for a pull request. For the `comment_id`, provide the ID of the review comment you are replying to. This must be the ID of a _top-level review comment_, not a reply to that comment. Replies to replies are not supported.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReplyForReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * Pull request reviews created in the `PENDING` state do not include the `submitted_at` property in the response.
+     *
+     * **Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#get-a-pull-request) endpoint.
+     *
+     * The `position` value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     */
+    createReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["createReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a review comment in the pull request diff. To add a regular comment to a pull request timeline, see "[Create an issue comment](https://docs.github.com/enterprise-server@2.22/rest/reference/issues#create-an-issue-comment)." We recommend creating a review comment using `line`, `side`, and optionally `start_line` and `start_side` if your comment applies to more than one line in the pull request diff.
+     *
+     * You can still create a review comment using the `position` parameter. When you use `position`, the `line`, `side`, `start_line`, and `start_side` parameters are not required. For more information, see the [`comfort-fade` preview notice](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#create-a-review-comment-for-a-pull-request-preview-notices).
+     *
+     * **Note:** The position value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePendingReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deletePendingReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deletePendingReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a review comment.
+     */
+    deleteReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** To dismiss a pull request review on a [protected branch](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#branches), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.
+     */
+    dismissReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["dismissReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["dismissReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists details of a pull request by providing its number.
+     *
+     * When you get, [create](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls/#create-a-pull-request), or [edit](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#update-a-pull-request) a pull request, GitHub Enterprise Server creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@2.22/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub Enterprise Server has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the _test_ merge commit.
+     *
+     * The value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
+     *
+     * *   If merged as a [merge commit](https://help.github.com/articles/about-merge-methods-on-github/), `merge_commit_sha` represents the SHA of the merge commit.
+     * *   If merged via a [squash](https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits), `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
+     * *   If [rebased](https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits), `merge_commit_sha` represents the commit that the base branch was updated to.
+     *
+     * Pass the appropriate [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["pulls"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["pulls"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["getReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides details for a review comment.
+     */
+    getReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["getReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List comments for a specific pull request review.
+     */
+    listCommentsForReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a maximum of 250 commits for a pull request. To receive a complete commit list for pull requests with more than 250 commits, use the [List commits](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#list-commits) endpoint.
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** Responses include a maximum of 3000 files. The paginated response returns 30 files per page by default.
+     */
+    listFiles: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listFiles"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
+     */
+    listReviewComments: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewComments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
+     */
+    listReviewCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The list of reviews returns in chronological order.
+     */
+    listReviews: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviews"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@2.22/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@2.22/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    requestReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["requestReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["requestReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    submitReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["submitReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["submitReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch.
+     */
+    updateBranch: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Update the review summary comment with new text.
+     */
+    updateReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables you to edit a review comment.
+     */
+    updateReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["updateReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  rateLimit: {
+    /**
+     * **Note:** Accessing this endpoint does not count against your REST API rate limit.
+     *
+     * **Note:** The `rate` object is deprecated. If you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["rateLimit"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["rateLimit"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  reactions: {
+    /**
+     * Create a reaction to a [commit comment](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#comments). A response with an HTTP `200` status means that you already added the reaction type to this commit comment.
+     */
+    createForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue](https://docs.github.com/enterprise-server@2.22/rest/reference/issues/). A response with an HTTP `200` status means that you already added the reaction type to this issue.
+     */
+    createForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue comment](https://docs.github.com/enterprise-server@2.22/rest/reference/issues#comments). A response with an HTTP `200` status means that you already added the reaction type to this issue comment.
+     */
+    createForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#comments). A response with an HTTP `200` status means that you already added the reaction type to this pull request review comment.
+     */
+    createForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion comment.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    createForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    createForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [commit comment](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#comments).
+     */
+    deleteForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/issues/:issue_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue](https://docs.github.com/enterprise-server@2.22/rest/reference/issues/).
+     */
+    deleteForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE delete /repositories/:repository_id/issues/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue comment](https://docs.github.com/enterprise-server@2.22/rest/reference/issues#comments).
+     */
+    deleteForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/pulls/comments/:comment_id/reactions/:reaction_id.`
+     *
+     * Delete a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#review-comments).
+     */
+    deleteForPullRequestComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Reactions API. We recommend migrating your existing code to use the new delete reactions endpoints. For more information, see this [blog post](https://developer.github.com/changes/2020-02-26-new-delete-reactions-endpoints/).
+     *
+     * OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), when deleting a [team discussion](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussions) or [team discussion comment](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussion-comments).
+     * @deprecated octokit.rest.reactions.deleteLegacy() is deprecated, see https://docs.github.com/enterprise-server@2.22/rest/reference/reactions/#delete-a-reaction-legacy
+     */
+    deleteLegacy: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteLegacy"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteLegacy"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [commit comment](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#comments).
+     */
+    listForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue](https://docs.github.com/enterprise-server@2.22/rest/reference/issues).
+     */
+    listForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue comment](https://docs.github.com/enterprise-server@2.22/rest/reference/issues#comments).
+     */
+    listForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [pull request review comment](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#review-comments).
+     */
+    listForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion comment](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussion-comments/). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    listForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#discussions). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    listForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["acceptInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["acceptInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified apps push access for this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * For more information the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * The invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#invitations).
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    addStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified teams push access for this branch. You can also give push access to child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified people push access for this branch.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    checkCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["checkCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["checkCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated**: Use `repos.compareCommitsWithBasehead()` (`GET /repos/{owner}/{repo}/compare/{basehead}`) instead. Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * To process a response with a large number of commits, you can use (`per_page` or `page`) to paginate the results. When using paging, the list of changed files is only returned with page 1, but includes all changed files for the entire comparison. For more information on working with pagination, see "[Traversing with pagination](/rest/guides/traversing-with-pagination)."
+     *
+     * When calling this API without any paging parameters (`per_page` or `page`), the returned list is limited to 250 commits and the last commit in the list is the most recent of the entire comparison. When a paging parameter is specified, the first commit in the returned list of each page is the earliest.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommits"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommits"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `basehead` param is comprised of two parts: `base` and `head`. Both must be branch names in `repo`. To compare branches across other repositories in the same network as `repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * The response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [List commits](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#list-commits) to enumerate all commits in the range.
+     *
+     * For comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long
+     * to generate. You can typically resolve this error by using a smaller commit range.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommitsWithBasehead: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a comment for a commit using its `:commit_sha`.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to require signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    createCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access in a repository can create commit statuses for a given SHA.
+     *
+     * Note: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.
+     */
+    createCommitStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can create a read-only deploy key.
+     */
+    createDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deployments offer a few configurable parameters with certain defaults.
+     *
+     * The `ref` parameter can be any named branch, tag, or SHA. At GitHub Enterprise Server we often deploy branches and verify them
+     * before we merge a pull request.
+     *
+     * The `environment` parameter allows deployments to be issued to different runtime environments. Teams often have
+     * multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This parameter
+     * makes it easier to track which environments have requested deployments. The default environment is `production`.
+     *
+     * The `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If
+     * the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds,
+     * the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will
+     * return a failure response.
+     *
+     * By default, [commit statuses](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#statuses) for every submitted context must be in a `success`
+     * state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to
+     * specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do
+     * not require any contexts or create any commit statuses, the deployment will always succeed.
+     *
+     * The `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text
+     * field that will be passed on when a deployment event is dispatched.
+     *
+     * The `task` parameter is used by the deployment system to allow different execution paths. In the web world this might
+     * be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an
+     * application with debugging enabled.
+     *
+     * Users with `repo` or `repo_deployment` scopes can create a deployment for a given ref.
+     *
+     * #### Merged branch response
+     * You will see this response when GitHub automatically merges the base branch into the topic branch instead of creating
+     * a deployment. This auto-merge happens when:
+     * *   Auto-merge option is enabled in the repository
+     * *   Topic branch does not include the latest changes on the base branch, which is `master` in the response example
+     * *   There are no merge conflicts
+     *
+     * If there are no new commits in the base branch, a new request to create a deployment should give a successful
+     * response.
+     *
+     * #### Merge conflict response
+     * This error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't
+     * be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.
+     *
+     * #### Failed commit status checks
+     * This error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success`
+     * status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.
+     */
+    createDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with `push` access can create deployment statuses for a given deployment.
+     *
+     * GitHub Apps require `read & write` access to "Deployments" and `read-only` access to "Repo contents" (for private repos). OAuth Apps require the `repo_deployment` scope.
+     */
+    createDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to trigger a webhook event called `repository_dispatch` when you want activity that happens outside of GitHub Enterprise Server to trigger a GitHub Actions workflow or GitHub App webhook. You must configure your GitHub Actions workflow or GitHub App to run when the `repository_dispatch` event occurs. For an example `repository_dispatch` webhook payload, see "[RepositoryDispatchEvent](https://docs.github.com/enterprise-server@2.22/webhooks/event-payloads/#repository_dispatch)."
+     *
+     * The `client_payload` parameter is available for any extra information that your workflow might need. This parameter is a JSON payload that will be passed on when the webhook event is dispatched. For example, the `client_payload` can include a message that a user would like to send using a GitHub Actions workflow. Or the `client_payload` can be used as a test to debug your workflow.
+     *
+     * This endpoint requires write access to the repository by providing either:
+     *
+     *   - Personal access tokens with `repo` scope. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)" in the GitHub Help documentation.
+     *   - GitHub Apps with both `metadata:read` and `contents:read&write` permissions.
+     *
+     * This input example shows how you can use the `client_payload` as a test to debug your workflow.
+     */
+    createDispatchEvent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDispatchEvent"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDispatchEvent"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository.
+     */
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a fork for the authenticated user.
+     *
+     * **Note**: Forking a Repository happens asynchronously. You may have to wait a short period of time before you can access the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub Enterprise Server Support](https://support.github.com/contact) or [GitHub Enterprise Server Premium Support](https://premium.githubsupport.com).
+     */
+    createFork: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createFork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createFork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository in the specified organization. The authenticated user must be a member of the organization.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createInOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new file or replaces an existing file in a repository.
+     */
+    createOrUpdateFileContents: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Configures a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages)."
+     */
+    createPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can create a release.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository using a repository template. Use the `template_owner` and `template_repo` route parameters to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the [Get a repository](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#get-a-repository) endpoint and check that the `is_template` key is `true`.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createUsingTemplate: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createUsingTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createUsingTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can
+     * share the same `config` as long as those webhooks do not have any `events` that overlap.
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    declineInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["declineInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["declineInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+     *
+     * If an organization owner has configured the organization to prevent members from deleting organization-owned
+     * repositories, you will get a `403 Forbidden` response.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Disables the ability to restrict who can push to this branch.
+     */
+    deleteAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    deleteAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deleteBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to disable required signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    deleteCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
+     */
+    deleteDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To ensure there can always be an active deployment, you can only delete an _inactive_ deployment. Anyone with `repo` or `repo_deployment` scopes can delete an inactive deployment.
+     *
+     * To set a deployment as inactive, you must:
+     *
+     * *   Create a new deployment that is active so that the system has a record of the current state, then delete the previously active deployment.
+     * *   Mark the active deployment as inactive by adding any non-successful deployment status.
+     *
+     * For more information, see "[Create a deployment](https://docs.github.com/enterprise-server@2.22/rest/reference/repos/#create-a-deployment)" and "[Create a deployment status](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#create-a-deployment-status)."
+     */
+    deleteDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a file in a repository.
+     *
+     * You can provide an additional `committer` parameter, which is an object containing information about the committer. Or, you can provide an `author` parameter, which is an object containing information about the author.
+     *
+     * The `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.
+     *
+     * You must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.
+     */
+    deleteFile: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteFile"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteFile"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deletePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can delete a release.
+     */
+    deleteRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a tar archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadTarballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a zip archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadZipballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you pass the `scarlet-witch-preview` media type, requests to get a repository will also return the repository's code of conduct if it can be detected from the repository's code of conduct file.
+     *
+     * The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["repos"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["repos"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists who has access to this protected branch.
+     *
+     * **Note**: Users, apps, and teams `restrictions` are only available for organization-owned repositories.
+     */
+    getAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAllStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllTopics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getAllTopics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the GitHub Apps that have push access to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     */
+    getAppsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+     */
+    getCodeFrequencyStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks the repository permission of a collaborator. The possible repository permissions are `admin`, `write`, `read`, and `none`.
+     */
+    getCollaboratorPermissionLevel: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
+     *
+     * The most recent status for each context is returned, up to 100. This field [paginates](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination) if there are over 100 contexts.
+     *
+     * Additionally, a combined `state` is returned. The `state` is one of:
+     *
+     * *   **failure** if any of the contexts report as `error` or `failure`
+     * *   **pending** if there are no statuses or a context is `pending`
+     * *   **success** if the latest status for all contexts is `success`
+     */
+    getCombinedStatusForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the contents of a single commit reference. You must have `read` access for the repository to use this endpoint.
+     *
+     * **Note:** If there are more than 300 files in the commit diff, the response will include pagination link headers for the remaining files, up to a limit of 3000 files. Each page contains the static commit information, and the only changes are to the file listing.
+     *
+     * You can pass the appropriate [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to  fetch `diff` and `patch` formats. Diffs with binary data will have no `patch` property.
+     *
+     * To return only the SHA-1 hash of the commit reference, you can provide the `sha` custom [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) in the `Accept` header. You can use this endpoint to check if a remote reference's SHA-1 hash is the same as your local reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.
+     */
+    getCommitActivityStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to check whether a branch requires signed commits. An enabled status of `true` indicates you must sign commits on this branch. For more information, see [Signing commits with GPG](https://help.github.com/articles/signing-commits-with-gpg) in GitHub Help.
+     *
+     * **Note**: You must enable branch protection to require signed commits.
+     */
+    getCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the contents of a file or directory in a repository. Specify the file path or directory in `:path`. If you omit
+     * `:path`, you will receive the contents of the repository's root directory. See the description below regarding what the API response includes for directories.
+     *
+     * Files and symlinks support [a custom media type](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#custom-media-types) for
+     * retrieving the raw content or rendered HTML (when supported). All content types support [a custom media
+     * type](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#custom-media-types) to ensure the content is returned in a consistent
+     * object format.
+     *
+     * **Note**:
+     * *   To get a repository's contents recursively, you can [recursively get the tree](https://docs.github.com/enterprise-server@2.22/rest/reference/git#trees).
+     * *   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees
+     * API](https://docs.github.com/enterprise-server@2.22/rest/reference/git#get-a-tree).
+     * *   This API supports files up to 1 megabyte in size.
+     *
+     * #### If the content is a directory
+     * The response will be an array of objects, one object for each item in the directory.
+     * When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value
+     * _should_ be "submodule". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW).
+     * In the next major version of the API, the type will be returned as "submodule".
+     *
+     * #### If the content is a symlink
+     * If the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the
+     * API responds with the content of the file (in the format shown in the example. Otherwise, the API responds with an object
+     * describing the symlink itself.
+     *
+     * #### If the content is a submodule
+     * The `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific
+     * commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out
+     * the submodule at that specific commit.
+     *
+     * If the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links["git"]`) and the
+     * github.com URLs (`html_url` and `_links["html"]`) will have null values.
+     */
+    getContent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getContent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the `total` number of commits authored by the contributor. In addition, the response includes a Weekly Hash (`weeks` array) with the following information:
+     *
+     * *   `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+     * *   `a` - Number of additions
+     * *   `d` - Number of deletions
+     * *   `c` - Number of commits
+     */
+    getContributorsStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContributorsStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getContributorsStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployKey"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployKey"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view a deployment status for a deployment:
+     */
+    getDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLatestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View the latest published full release for the repository.
+     *
+     * The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
+     */
+    getLatestRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestRelease"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestRelease"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPagesBuild"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPagesBuild"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.
+     *
+     * The array order is oldest week (index 0) to most recent week.
+     */
+    getParticipationStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getParticipationStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getParticipationStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getPullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Each array contains the day number, hour number, and number of commits:
+     *
+     * *   `0-6`: Sunday - Saturday
+     * *   `0-23`: Hour of day
+     * *   Number of commits
+     *
+     * For example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+     */
+    getPunchCardStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPunchCardStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPunchCardStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the preferred README for a repository.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadme: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadme"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getReadme"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the README from a repository directory.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadmeInDirectory: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#hypermedia).
+     */
+    getRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.
+     */
+    getReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a published release with the specified tag.
+     */
+    getReleaseByTag: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseByTag"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getStatusChecksProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the teams who have push access to this branch. The list includes child teams.
+     */
+    getTeamsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the people who have push access to this branch.
+     */
+    getUsersWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in a repository. To get only the webhook `config` properties, see "[Get a webhook configuration for a repository](/rest/reference/repos#get-a-webhook-configuration-for-a-repository)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listBranches: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranches"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listBranches"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Returns all branches where the given commit SHA is the HEAD, or latest commit for the branch.
+     */
+    listBranchesForHeadCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use the `:commit_sha` to specify the commit that will have its comments listed.
+     */
+    listCommentsForCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Commit Comments use [these custom media types](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#custom-media-types). You can read more about the use of media types in the API [here](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/).
+     *
+     * Comments are ordered by ascending ID.
+     */
+    listCommitCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.
+     *
+     * This resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.
+     */
+    listCommitStatusesForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
+     *
+     * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
+     */
+    listContributors: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listContributors"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listContributors"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listDeployKeys: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view deployment statuses for a deployment:
+     */
+    listDeploymentStatuses: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Simple filtering of deployments is available via query parameters:
+     */
+    listDeployments: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories for the specified organization.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public repositories for the specified user. Note: For GitHub AE, this endpoint will list internal repositories for the specified user.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.
+     */
+    listInvitations: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user, this endpoint will list all currently open repository invitations for that user.
+     */
+    listInvitationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.
+     */
+    listLanguages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listLanguages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listLanguages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPagesBuilds: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPagesBuilds"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPagesBuilds"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all public repositories in the order that they were created.
+     *
+     * Note:
+     * - For GitHub Enterprise Server, this endpoint will only list repositories available to all users on the enterprise.
+     * - Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of repositories.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, additionally returns open pull requests associated with the commit. The results may include open and closed pull requests. Additional preview headers may be required to see certain details for associated pull requests, such as whether a pull request is in a draft state. For more information about previews that might affect this endpoint, see the [List pull requests](https://docs.github.com/enterprise-server@2.22/rest/reference/pulls#list-pull-requests) endpoint.
+     */
+    listPullRequestsAssociatedWithCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReleaseAssets: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleaseAssets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#list-repository-tags).
+     *
+     * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+     */
+    listReleases: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleases"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listReleases"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTags: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTags"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTags"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTeams: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTeams"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTeams"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@2.22/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of an app to push to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a team to push to this branch. You can also remove push access for child teams.
+     *
+     * | Type    | Description                                                                                                                                         |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a user to push to this branch.
+     *
+     * | Type    | Description                                                                                                                                   |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames of the people who should no longer have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    replaceAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["replaceAllTopics"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["replaceAllTopics"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.
+     *
+     * Build requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.
+     */
+    requestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["requestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["requestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    setAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of apps that have push access to this branch. This removes all apps that previously had push access and grants push access to the new list of apps. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    setStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. Team restrictions include child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.
+     *
+     * **Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`
+     */
+    testPushWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["testPushWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["testPushWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * A transfer request will need to be accepted by the new owner when transferring a personal repository to another user. The response will contain the original `owner`, and the transfer will continue asynchronously. For more details on the requirements to transfer personal and organization-owned repositories, see [about repository transfers](https://help.github.com/articles/about-repository-transfers/).
+     */
+    transfer: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["transfer"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["transfer"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: To edit a repository's topics, use the [Replace all repository topics](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#replace-all-repository-topics) endpoint.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Protecting a branch requires admin or owner permissions to the repository.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     *
+     * **Note**: The list of users, apps, and teams in total is limited to 100 items.
+     */
+    updateBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates information for a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages).
+     */
+    updateInformationAboutPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     */
+    updatePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release.
+     */
+    updateRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release asset.
+     */
+    updateReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    updateStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in a repository. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for a repository](/rest/reference/repos#update-a-webhook-configuration-for-a-repository)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint makes use of [a Hypermedia relation](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#hypermedia) to determine which URL to access. The endpoint you call to upload release assets is specific to your release. Use the `upload_url` returned in
+     * the response of the [Create a release endpoint](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#create-a-release) to upload a release asset.
+     *
+     * You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.
+     *
+     * Most libraries will set the required `Content-Length` header automatically. Use the required `Content-Type` header to provide the media type of the asset. For a list of media types, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). For example:
+     *
+     * `application/zip`
+     *
+     * GitHub Enterprise Server expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body. Everything else about the endpoint is the same as the rest of the API. For example,
+     * you'll still need to pass your authentication to be able to upload an asset.
+     *
+     * When an upstream failure occurs, you will receive a `502 Bad Gateway` status. This may leave an empty asset with a state of `starter`. It can be safely deleted.
+     *
+     * **Notes:**
+     * *   GitHub Enterprise Server renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "[List assets for a release](https://docs.github.com/enterprise-server@2.22/rest/reference/repos#list-assets-for-a-release)"
+     * endpoint lists the renamed filenames. For more information and help, contact [GitHub Enterprise Server Support](https://support.github.com/contact).
+     * *   If you upload an asset with the same filename as another uploaded asset, you'll receive an error and must delete the old file before you can re-upload the new asset.
+     */
+    uploadReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  search: {
+    /**
+     * Searches for query terms inside of a file. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for code, you can get text match metadata for the file **content** and file **path** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery) repository, your query would look something like this:
+     *
+     * `q=addClass+in:file+language:js+repo:jquery/jquery`
+     *
+     * This query searches for the keyword `addClass` within a file's contents. The query limits the search to files where the language is JavaScript in the `jquery/jquery` repository.
+     *
+     * #### Considerations for code search
+     *
+     * Due to the complexity of searching code, there are a few restrictions on how searches are performed:
+     *
+     * *   Only the _default branch_ is considered. In most cases, this will be the `master` branch.
+     * *   Only files smaller than 384 KB are searchable.
+     * *   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing
+     * language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.
+     */
+    code: {
+      (
+        params?: RestEndpointMethodTypes["search"]["code"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["code"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find commits via various criteria on the default branch (usually `master`). This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for commits, you can get text match metadata for the **message** field when you provide the `text-match` media type. For more details about how to receive highlighted search results, see [Text match
+     * metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:
+     *
+     * `q=repo:octocat/Spoon-Knife+css`
+     */
+    commits: {
+      (
+        params?: RestEndpointMethodTypes["search"]["commits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["commits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find issues by state and keyword. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields when you pass the `text-match` media type. For more details about how to receive highlighted
+     * search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.
+     *
+     * `q=windows+label:bug+language:python+state:open&sort=created&order=asc`
+     *
+     * This query searches for the keyword `windows`, within any open issue that is labeled as `bug`. The search runs across repositories whose primary language is Python. The results are sorted by creation date in ascending order, which means the oldest issues appear first in the search results.
+     *
+     * **Note:** For [user-to-server](https://docs.github.com/developers/apps/identifying-and-authorizing-users-for-github-apps#user-to-server-requests) GitHub App requests, you can't retrieve a combination of issues and pull requests in a single query. Requests that don't include the `is:issue` or `is:pull-request` qualifier will receive an HTTP `422 Unprocessable Entity` response. To get results for both issues and pull requests, you must send separate queries for issues and pull requests. For more information about the `is` qualifier, see "[Searching only issues or pull requests](https://docs.github.com/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-only-issues-or-pull-requests)."
+     */
+    issuesAndPullRequests: {
+      (
+        params?: RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find labels in a repository with names or descriptions that match search keywords. Returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for labels, you can get text match metadata for the label **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find labels in the `linguist` repository that match `bug`, `defect`, or `enhancement`. Your query might look like this:
+     *
+     * `q=bug+defect+enhancement&repository_id=64778136`
+     *
+     * The labels that best match the query appear first in the search results.
+     */
+    labels: {
+      (
+        params?: RestEndpointMethodTypes["search"]["labels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["labels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find repositories via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for repositories, you can get text match metadata for the **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for popular Tetris repositories written in assembly code, your query might look like this:
+     *
+     * `q=tetris+language:assembly&sort=stars&order=desc`
+     *
+     * This query searches for repositories with the word `tetris` in the name, the description, or the README. The results are limited to repositories where the primary language is assembly. The results are sorted by stars in descending order, so that the most popular repositories appear first in the search results.
+     *
+     * When you include the `mercy` preview header, you can also search for multiple topics by adding more `topic:` instances. For example, your query might look like this:
+     *
+     * `q=topic:ruby+topic:rails`
+     */
+    repos: {
+      (
+        params?: RestEndpointMethodTypes["search"]["repos"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["repos"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find topics via various criteria. Results are sorted by best match. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination). See "[Searching topics](https://help.github.com/articles/searching-topics/)" for a detailed list of qualifiers.
+     *
+     * When searching for topics, you can get text match metadata for the topic's **short\_description**, **description**, **name**, or **display\_name** field when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for topics related to Ruby that are featured on https://github.com/topics. Your query might look like this:
+     *
+     * `q=ruby+is:featured`
+     *
+     * This query searches for topics with the keyword `ruby` and limits the results to find only topics that are featured. The topics that are the best match for the query appear first in the search results.
+     */
+    topics: {
+      (
+        params?: RestEndpointMethodTypes["search"]["topics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["topics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find users via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields when you pass the `text-match` media type. For more details about highlighting search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata). For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@2.22/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you're looking for a list of popular users, you might try this query:
+     *
+     * `q=tom+repos:%3E42+followers:%3E1000`
+     *
+     * This query searches for users with the name `tom`. The results are restricted to users with more than 42 repositories and over 1,000 followers.
+     */
+    users: {
+      (
+        params?: RestEndpointMethodTypes["search"]["users"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["users"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  teams: {
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adds an organization member to a team. An authenticated organization owner or team maintainer can add organization members to a team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * An organization owner can add someone who is not part of the team's organization to a team. When an organization owner adds someone to a team who is not an organization member, this endpoint will send an invitation to the person via email. This newly-created membership will be in the "pending" state until the person accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team.
+     *
+     * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    addOrUpdateMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    addOrUpdateProjectPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     *
+     * For more information about the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     */
+    addOrUpdateRepoPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    checkPermissionsForProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `admin`, `push`, `maintain`, `triage`, or `pull` permission for a repository. Repositories inherited through a parent team will also be checked.
+     *
+     * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://docs.github.com/enterprise-server@2.22/rest/overview/media-types/) via the `application/vnd.github.v3.repository+json` accept header.
+     *
+     * If a team doesn't have permission for the repository, you will receive a `404 Not Found` response status.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    checkPermissionsForRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams. Organization owners can limit team creation to organization owners. For more information, see "[Setting team creation permissions](https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization)."
+     *
+     * When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of `maintainers`. For more information, see "[About teams](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    createDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@2.22/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    createDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    deleteDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    deleteDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To delete a team, the authenticated user must be an organization owner or team maintainer.
+     *
+     * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}`.
+     */
+    deleteInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["deleteInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a team using the team's `slug`. GitHub Enterprise Server generates the `slug` from the team `name`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}`.
+     */
+    getByName: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getByName"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["getByName"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    getDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    getDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To get a user's membership with a team, the team must be visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     *
+     * **Note:**
+     * The response contains the `state` of the membership and the member's `role`.
+     *
+     * The `role` for organization owners is set to `maintainer`. For more information about `maintainer` roles, see see [Create a team](https://docs.github.com/enterprise-server@2.22/rest/reference/teams#create-a-team).
+     */
+    getMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all teams in an organization that are visible to the authenticated user.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the child teams of the team specified by `{team_slug}`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/teams`.
+     */
+    listChildInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listChildInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listChildInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    listDiscussionCommentsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    listDiscussionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/).
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To list members in a team, the team must be visible to the authenticated user.
+     */
+    listMembersInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listMembersInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listMembersInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organization projects for a team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects`.
+     */
+    listProjectsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a team's repositories visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos`.
+     */
+    listReposInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listReposInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listReposInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    removeMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. This endpoint removes the project from the team, but does not delete the project.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    removeProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. This does not delete the repository, it just removes it from the team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    removeRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    updateDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    updateDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}`.
+     */
+    updateInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["updateInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  users: {
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    addEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPersonIsFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a GPG key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    deleteEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GPG key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deletePublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    follow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["follow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["follow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is authenticated through basic authentication or OAuth with the `user` scope, then the response lists public and private profile information.
+     *
+     * If the authenticated user is authenticated through OAuth without the `user` scope, then the response lists only public profile information.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides publicly available information about someone with a GitHub account.
+     *
+     * GitHub Apps with the `Plan` user permission can use this endpoint to retrieve information about a user's GitHub Enterprise Server plan. The GitHub App must be authenticated as a user. See "[Identifying and authorizing users for GitHub Apps](https://docs.github.com/enterprise-server@2.22/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)" for details about authentication. For an example response, see 'Response with GitHub Enterprise Server plan information' below"
+     *
+     * The `email` key in the following response is the publicly visible email address from your GitHub Enterprise Server [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub Enterprise Server. For more information, see [Authentication](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#authentication).
+     *
+     * The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "[Emails API](https://docs.github.com/enterprise-server@2.22/rest/reference/users#emails)".
+     */
+    getByUsername: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getByUsername"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["getByUsername"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides hovercard information when authenticated through basic auth or OAuth with the `repo` scope. You can find out more about someone in relation to their pull requests, issues, repositories, and organizations.
+     *
+     * The `subject_type` and `subject_id` parameters provide context for the person's hovercard, which returns more information than without the parameters. For example, if you wanted to find out more about `octocat` who owns the `Spoon-Knife` repository via cURL, it would look like this:
+     *
+     * ```shell
+     *  curl -u username:token
+     *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
+     * ```
+     */
+    getContextForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getContextForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getContextForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all users, in the order that they signed up on GitHub Enterprise Server. This list includes personal user accounts and organization accounts.
+     *
+     * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@2.22/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of users.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["users"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.
+     */
+    listEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the authenticated user follows.
+     */
+    listFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the authenticated user.
+     */
+    listFollowersForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the specified user.
+     */
+    listFollowersForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the specified user follows.
+     */
+    listFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listGpgKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the GPG keys for a user. This information is accessible by anyone.
+     */
+    listGpgKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists your publicly visible email address, which you can set with the [Set primary email visibility for the authenticated user](https://docs.github.com/enterprise-server@2.22/rest/reference/users#set-primary-email-visibility-for-the-authenticated-user) endpoint. This endpoint is accessible with the `user:email` scope.
+     */
+    listPublicEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the _verified_ public SSH keys for a user. This is accessible by anyone.
+     */
+    listPublicKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@2.22/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listPublicSshKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    unfollow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["unfollow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["unfollow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.
+     */
+    updateAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["updateAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["updateAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+};

--- a/src/generated/ghe-222-parameters-and-response-types.ts
+++ b/src/generated/ghe-222-parameters-and-response-types.ts
@@ -1,0 +1,4564 @@
+import { Endpoints, RequestParameters } from "@octokit/types";
+
+export type RestEndpointMethodTypes = {
+  actions: {
+    addSelectedRepoToOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["response"];
+    };
+    cancelWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel"]["response"];
+    };
+    createOrUpdateOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}"]["response"];
+    };
+    createOrUpdateRepoSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["response"];
+    };
+    createRegistrationTokenForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/actions/runners/registration-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/actions/runners/registration-token"]["response"];
+    };
+    createRegistrationTokenForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runners/registration-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runners/registration-token"]["response"];
+    };
+    createRemoveTokenForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/actions/runners/remove-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/actions/runners/remove-token"]["response"];
+    };
+    createRemoveTokenForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runners/remove-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runners/remove-token"]["response"];
+    };
+    createWorkflowDispatch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"]["response"];
+    };
+    deleteArtifact: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["response"];
+    };
+    deleteOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}"]["response"];
+    };
+    deleteRepoSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["response"];
+    };
+    deleteSelfHostedRunnerFromOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/runners/{runner_id}"]["response"];
+    };
+    deleteSelfHostedRunnerFromRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}"]["response"];
+    };
+    deleteWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"]["response"];
+    };
+    deleteWorkflowRunLogs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["response"];
+    };
+    downloadArtifact: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"]["response"];
+    };
+    downloadJobLogsForWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"]["response"];
+    };
+    downloadWorkflowRunLogs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["response"];
+    };
+    getArtifact: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["response"];
+    };
+    getJobForWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"]["response"];
+    };
+    getOrgPublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets/public-key"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets/public-key"]["response"];
+    };
+    getOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}"]["response"];
+    };
+    getRepoPublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/secrets/public-key"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/secrets/public-key"]["response"];
+    };
+    getRepoSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["response"];
+    };
+    getSelfHostedRunnerForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/runners/{runner_id}"]["response"];
+    };
+    getSelfHostedRunnerForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runners/{runner_id}"]["response"];
+    };
+    getWorkflow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}"]["response"];
+    };
+    getWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}"]["response"];
+    };
+    listArtifactsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/artifacts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts"]["response"];
+    };
+    listJobsForWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"]["response"];
+    };
+    listOrgSecrets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets"]["response"];
+    };
+    listRepoSecrets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/secrets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/secrets"]["response"];
+    };
+    listRepoWorkflows: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/workflows"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/workflows"]["response"];
+    };
+    listRunnerApplicationsForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/runners/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/runners/downloads"]["response"];
+    };
+    listRunnerApplicationsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runners/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runners/downloads"]["response"];
+    };
+    listSelectedReposForOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}/repositories"]["response"];
+    };
+    listSelfHostedRunnersForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/runners"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/runners"]["response"];
+    };
+    listSelfHostedRunnersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runners"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runners"]["response"];
+    };
+    listWorkflowRunArtifacts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"]["response"];
+    };
+    listWorkflowRuns: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs"]["response"];
+    };
+    listWorkflowRunsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs"]["response"];
+    };
+    reRunWorkflow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"]["response"];
+    };
+    removeSelectedRepoFromOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["response"];
+    };
+    setSelectedReposForOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"]["response"];
+    };
+  };
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred/{owner}/{repo}"]["response"];
+    };
+    deleteRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    deleteThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    getFeeds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /feeds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /feeds"]["response"];
+    };
+    getRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    getThread: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}"]["response"];
+    };
+    getThreadSubscriptionForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    listEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events"]["response"];
+    };
+    listNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications"]["response"];
+    };
+    listOrgEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/orgs/{org}"]["response"];
+    };
+    listPublicEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /events"]["response"];
+    };
+    listPublicEventsForRepoNetwork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /networks/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /networks/{owner}/{repo}/events"]["response"];
+    };
+    listPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/public"]["response"];
+    };
+    listPublicOrgEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/events"]["response"];
+    };
+    listReceivedEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events"]["response"];
+    };
+    listReceivedPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events/public"]["response"];
+    };
+    listRepoEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/events"]["response"];
+    };
+    listRepoNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    listReposStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred"]["response"];
+    };
+    listReposStarredByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/starred"]["response"];
+    };
+    listReposWatchedByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/subscriptions"]["response"];
+    };
+    listStargazersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stargazers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stargazers"]["response"];
+    };
+    listWatchedReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/subscriptions"]["response"];
+    };
+    listWatchersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscribers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscribers"]["response"];
+    };
+    markNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications"]["response"];
+    };
+    markRepoNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    markThreadAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /notifications/threads/{thread_id}"]["response"];
+    };
+    setRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    setThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    starRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/starred/{owner}/{repo}"]["response"];
+    };
+    unstarRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/starred/{owner}/{repo}"]["response"];
+    };
+  };
+  apps: {
+    addRepoToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    checkToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /applications/{client_id}/token"]["response"];
+    };
+    createContentAttachment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createContentAttachmentForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createFromManifest: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app-manifests/{code}/conversions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app-manifests/{code}/conversions"]["response"];
+    };
+    createInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app/installations/{installation_id}/access_tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app/installations/{installation_id}/access_tokens"]["response"];
+    };
+    deleteAuthorization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/grant"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/grant"]["response"];
+    };
+    deleteInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /app/installations/{installation_id}"]["response"];
+    };
+    deleteToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/token"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app"]["response"];
+    };
+    getBySlug: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /apps/{app_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /apps/{app_slug}"]["response"];
+    };
+    getInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations/{installation_id}"]["response"];
+    };
+    getOrgInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installation"]["response"];
+    };
+    getRepoInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/installation"]["response"];
+    };
+    getUserInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/installation"]["response"];
+    };
+    listInstallationReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations/{installation_id}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations/{installation_id}/repositories"]["response"];
+    };
+    listInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations"]["response"];
+    };
+    listInstallationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations"]["response"];
+    };
+    listReposAccessibleToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /installation/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /installation/repositories"]["response"];
+    };
+    removeRepoFromInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    resetToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /applications/{client_id}/token"]["response"];
+    };
+    revokeInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /installation/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /installation/token"]["response"];
+    };
+    suspendInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /app/installations/{installation_id}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /app/installations/{installation_id}/suspended"]["response"];
+    };
+    unsuspendInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /app/installations/{installation_id}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /app/installations/{installation_id}/suspended"]["response"];
+    };
+  };
+  checks: {
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-runs"]["response"];
+    };
+    createSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+    getSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["response"];
+    };
+    listAnnotations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["response"];
+    };
+    listForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["response"];
+    };
+    listForSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["response"];
+    };
+    listSuitesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["response"];
+    };
+    rerequestSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["response"];
+    };
+    setSuitesPreferences: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+  };
+  codeScanning: {
+    getAlert: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["response"];
+    };
+    listAlertsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts"]["response"];
+    };
+    listRecentAnalyses: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/code-scanning/analyses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/code-scanning/analyses"]["response"];
+    };
+    updateAlert: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["response"];
+    };
+    uploadSarif: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/code-scanning/sarifs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/code-scanning/sarifs"]["response"];
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct"]["response"];
+    };
+    getConductCode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct/{key}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct/{key}"]["response"];
+    };
+  };
+  emojis: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /emojis"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /emojis"]["response"];
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/settings/authorized-keys"]["response"];
+    };
+    createEnterpriseServerLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/start"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/start"]["response"];
+    };
+    createGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks"]["response"];
+    };
+    createImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users/{username}/authorizations"]["response"];
+    };
+    createOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/organizations"]["response"];
+    };
+    createPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments"]["response"];
+    };
+    createPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-hooks"]["response"];
+    };
+    createUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users"]["response"];
+    };
+    deleteGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/hooks/{hook_id}"]["response"];
+    };
+    deleteImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}/authorizations"]["response"];
+    };
+    deletePersonalAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/tokens/{token_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/tokens/{token_id}"]["response"];
+    };
+    deletePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    deletePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    deletePublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/keys/{key_ids}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/keys/{key_ids}"]["response"];
+    };
+    deleteUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}"]["response"];
+    };
+    demoteSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/site_admin"]["response"];
+    };
+    enableOrDisableMaintenanceMode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/maintenance"]["response"];
+    };
+    getAllAuthorizedSshKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings/authorized-keys"]["response"];
+    };
+    getAllStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/gists"]["response"];
+    };
+    getCommentStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/comments"]["response"];
+    };
+    getConfigurationStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/configcheck"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/configcheck"]["response"];
+    };
+    getDownloadStatusForPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["response"];
+    };
+    getGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks/{hook_id}"]["response"];
+    };
+    getHooksStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/hooks"]["response"];
+    };
+    getIssueStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/issues"]["response"];
+    };
+    getLicenseInformation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/settings/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/settings/license"]["response"];
+    };
+    getMaintenanceStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/maintenance"]["response"];
+    };
+    getMilestoneStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/milestones"]["response"];
+    };
+    getOrgStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/orgs"]["response"];
+    };
+    getPagesStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pages"]["response"];
+    };
+    getPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    getPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPullRequestStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pulls"]["response"];
+    };
+    getRepoStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/repos"]["response"];
+    };
+    getSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings"]["response"];
+    };
+    getUserStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/users"]["response"];
+    };
+    listGlobalWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks"]["response"];
+    };
+    listPersonalAccessTokens: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/tokens"]["response"];
+    };
+    listPreReceiveEnvironments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments"]["response"];
+    };
+    listPreReceiveHooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["response"];
+    };
+    listPublicKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/keys"]["response"];
+    };
+    pingGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks/{hook_id}/pings"]["response"];
+    };
+    promoteUserToBeSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/site_admin"]["response"];
+    };
+    removeAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /setup/api/settings/authorized-keys"]["response"];
+    };
+    removePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    removePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    setSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /setup/api/settings"]["response"];
+    };
+    startConfigurationProcess: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/configure"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/configure"]["response"];
+    };
+    startPreReceiveEnvironmentDownload: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["response"];
+    };
+    suspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/suspended"]["response"];
+    };
+    syncLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["response"];
+    };
+    syncLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/users/{username}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/users/{username}/sync"]["response"];
+    };
+    unsuspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/suspended"]["response"];
+    };
+    updateGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/hooks/{hook_id}"]["response"];
+    };
+    updateLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["response"];
+    };
+    updateLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["response"];
+    };
+    updateOrgName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/organizations/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/organizations/{org}"]["response"];
+    };
+    updatePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    updatePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updateUsernameForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/users/{username}"]["response"];
+    };
+    upgradeLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/upgrade"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/upgrade"]["response"];
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/star"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/comments"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    fork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/forks"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    getRevision: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/{sha}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/commits"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gists"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/forks"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/public"]["response"];
+    };
+    listStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/starred"]["response"];
+    };
+    star: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /gists/{gist_id}/star"]["response"];
+    };
+    unstar: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/star"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+  };
+  git: {
+    createBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["response"];
+    };
+    createCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/commits"]["response"];
+    };
+    createRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/refs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/refs"]["response"];
+    };
+    createTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/tags"]["response"];
+    };
+    createTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/trees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/trees"]["response"];
+    };
+    deleteRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+    getBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["response"];
+    };
+    getRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["response"];
+    };
+    getTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["response"];
+    };
+    getTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["response"];
+    };
+    listMatchingRefs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["response"];
+    };
+    updateRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+  };
+  gitignore: {
+    getAllTemplates: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates"]["response"];
+    };
+    getTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates/{name}"]["response"];
+    };
+  };
+  issues: {
+    addAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    addLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    checkUserCanBeAssigned: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    createLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/labels"]["response"];
+    };
+    createMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    deleteLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    deleteMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    getEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["response"];
+    };
+    getLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    getMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /issues"]["response"];
+    };
+    listAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    listCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["response"];
+    };
+    listEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["response"];
+    };
+    listEventsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events"]["response"];
+    };
+    listEventsForTimeline: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/issues"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/issues"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
+    };
+    listLabelsForMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["response"];
+    };
+    listLabelsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels"]["response"];
+    };
+    listLabelsOnIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    listMilestones: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    lock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    removeAllLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    removeAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    removeLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["response"];
+    };
+    setLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    unlock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    updateLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    updateMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+  };
+  licenses: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses/{license}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses/{license}"]["response"];
+    };
+    getAllCommonlyUsed: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses"]["response"];
+    };
+    getForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/license"]["response"];
+    };
+  };
+  markdown: {
+    render: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown"]["response"];
+    };
+    renderRaw: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown/raw"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown/raw"]["response"];
+    };
+  };
+  meta: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /meta"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /meta"]["response"];
+    };
+    getOctocat: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /octocat"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /octocat"]["response"];
+    };
+    getZen: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /zen"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /zen"]["response"];
+    };
+    root: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /"]["response"];
+    };
+  };
+  orgs: {
+    checkMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members/{username}"]["response"];
+    };
+    checkPublicMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members/{username}"]["response"];
+    };
+    convertMemberToOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}"]["response"];
+    };
+    getMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs/{org}"]["response"];
+    };
+    getMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/memberships/{username}"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /organizations"]["response"];
+    };
+    listAppInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installations"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/orgs"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/orgs"]["response"];
+    };
+    listMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members"]["response"];
+    };
+    listMembershipsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs"]["response"];
+    };
+    listOutsideCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/outside_collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/outside_collaborators"]["response"];
+    };
+    listPublicMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeMember: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/members/{username}"]["response"];
+    };
+    removeMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/memberships/{username}"]["response"];
+    };
+    removeOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    removePublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/public_members/{username}"]["response"];
+    };
+    setMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/memberships/{username}"]["response"];
+    };
+    setPublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/public_members/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}"]["response"];
+    };
+    updateMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/memberships/orgs/{org}"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+  };
+  projects: {
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    createCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/cards"]["response"];
+    };
+    createColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/{project_id}/columns"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/projects"]["response"];
+    };
+    createForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/projects"]["response"];
+    };
+    createForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/projects"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}"]["response"];
+    };
+    deleteCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/cards/{card_id}"]["response"];
+    };
+    deleteColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/{column_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}"]["response"];
+    };
+    getCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/cards/{card_id}"]["response"];
+    };
+    getColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}"]["response"];
+    };
+    getPermissionForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["response"];
+    };
+    listCards: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}/cards"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators"]["response"];
+    };
+    listColumns: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/columns"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/projects"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/projects"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/projects"]["response"];
+    };
+    moveCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/cards/{card_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/cards/{card_id}/moves"]["response"];
+    };
+    moveColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/moves"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/{project_id}"]["response"];
+    };
+    updateCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/cards/{card_id}"]["response"];
+    };
+    updateColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/{column_id}"]["response"];
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    createReplyForReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["response"];
+    };
+    createReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    createReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    deletePendingReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    deleteReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    dismissReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    getReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    getReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    listCommentsForReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["response"];
+    };
+    listFiles: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["response"];
+    };
+    listRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    listReviewComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    listReviewCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["response"];
+    };
+    listReviews: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    removeRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    requestReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    submitReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    updateBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["response"];
+    };
+    updateReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    updateReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+  };
+  rateLimit: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /rate_limit"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /rate_limit"]["response"];
+    };
+  };
+  reactions: {
+    createForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    createForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    createForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    createForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    createForTeamDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    createForTeamDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["response"];
+    };
+    deleteForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForPullRequestComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForTeamDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForTeamDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteLegacy: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /reactions/{reaction_id}"]["response"];
+    };
+    listForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    listForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    listForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    listForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    listForTeamDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    listForTeamDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["response"];
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    addAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    addStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    addTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    addUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    checkCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    compareCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["response"];
+    };
+    compareCommitsWithBasehead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["response"];
+    };
+    createCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    createCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    createCommitStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["response"];
+    };
+    createDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/keys"]["response"];
+    };
+    createDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    createDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    createDispatchEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/dispatches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/dispatches"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/repos"]["response"];
+    };
+    createFork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/forks"]["response"];
+    };
+    createInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/repos"]["response"];
+    };
+    createOrUpdateFileContents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    createPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages"]["response"];
+    };
+    createRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/releases"]["response"];
+    };
+    createUsingTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    declineInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}"]["response"];
+    };
+    deleteAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    deleteAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    deleteBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    deleteCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    deleteCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    deleteDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    deleteDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    deleteFile: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    deleteInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    deletePagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pages"]["response"];
+    };
+    deletePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    deleteRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    deleteReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    downloadTarballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["response"];
+    };
+    downloadZipballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}"]["response"];
+    };
+    getAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    getAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    getAllStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    getAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/topics"]["response"];
+    };
+    getAppsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    getBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["response"];
+    };
+    getBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    getCodeFrequencyStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["response"];
+    };
+    getCollaboratorPermissionLevel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["response"];
+    };
+    getCombinedStatusForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["response"];
+    };
+    getCommitActivityStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["response"];
+    };
+    getCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    getCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    getContent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    getContributorsStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["response"];
+    };
+    getDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    getDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    getDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["response"];
+    };
+    getLatestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["response"];
+    };
+    getLatestRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["response"];
+    };
+    getPages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages"]["response"];
+    };
+    getPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["response"];
+    };
+    getParticipationStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["response"];
+    };
+    getPullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    getPunchCardStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["response"];
+    };
+    getReadme: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme"]["response"];
+    };
+    getReadmeInDirectory: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["response"];
+    };
+    getRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    getReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    getReleaseByTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["response"];
+    };
+    getStatusChecksProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    getTeamsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    getUsersWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    listBranches: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches"]["response"];
+    };
+    listBranchesForHeadCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators"]["response"];
+    };
+    listCommentsForCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    listCommitCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments"]["response"];
+    };
+    listCommitStatusesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits"]["response"];
+    };
+    listContributors: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contributors"]["response"];
+    };
+    listDeployKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys"]["response"];
+    };
+    listDeploymentStatuses: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    listDeployments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repos"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/repos"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/repos"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/forks"]["response"];
+    };
+    listInvitations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/invitations"]["response"];
+    };
+    listInvitationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repository_invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repository_invitations"]["response"];
+    };
+    listLanguages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/languages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/languages"]["response"];
+    };
+    listPagesBuilds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repositories"]["response"];
+    };
+    listPullRequestsAssociatedWithCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["response"];
+    };
+    listReleaseAssets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["response"];
+    };
+    listReleases: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases"]["response"];
+    };
+    listTags: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tags"]["response"];
+    };
+    listTeams: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/teams"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/merges"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/merges"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    removeStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    removeStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    removeTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    removeUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    replaceAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/topics"]["response"];
+    };
+    requestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    setAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    setAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    setStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    setTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    setUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    testPushWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["response"];
+    };
+    transfer: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/transfer"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/transfer"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}"]["response"];
+    };
+    updateBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    updateCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    updateInformationAboutPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pages"]["response"];
+    };
+    updateInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    updatePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    updateRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    updateReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    updateStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    uploadReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["response"];
+    };
+  };
+  search: {
+    code: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/code"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/code"]["response"];
+    };
+    commits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/commits"]["response"];
+    };
+    issuesAndPullRequests: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/issues"]["response"];
+    };
+    labels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/labels"]["response"];
+    };
+    repos: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/repositories"]["response"];
+    };
+    topics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/topics"]["response"];
+    };
+    users: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/users"]["response"];
+    };
+  };
+  teams: {
+    addOrUpdateMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    addOrUpdateProjectPermissionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    addOrUpdateRepoPermissionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    checkPermissionsForProjectInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    checkPermissionsForRepoInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams"]["response"];
+    };
+    createDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["response"];
+    };
+    createDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions"]["response"];
+    };
+    deleteDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    deleteDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    deleteInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getByName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    getDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    getMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams"]["response"];
+    };
+    listChildInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/teams"]["response"];
+    };
+    listDiscussionCommentsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["response"];
+    };
+    listDiscussionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/teams"]["response"];
+    };
+    listMembersInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["response"];
+    };
+    listProjectsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/projects"]["response"];
+    };
+    listReposInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/repos"]["response"];
+    };
+    removeMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    removeProjectInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    removeRepoInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    updateDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    updateDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    updateInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+  };
+  users: {
+    addEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/emails"]["response"];
+    };
+    checkFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following/{target_user}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following/{target_user}"]["response"];
+    };
+    checkPersonIsFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following/{username}"]["response"];
+    };
+    createGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/gpg_keys"]["response"];
+    };
+    createPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/keys"]["response"];
+    };
+    deleteEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/emails"]["response"];
+    };
+    deleteGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    deletePublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/keys/{key_id}"]["response"];
+    };
+    follow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/following/{username}"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user"]["response"];
+    };
+    getByUsername: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}"]["response"];
+    };
+    getContextForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/hovercard"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/hovercard"]["response"];
+    };
+    getGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    getPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys/{key_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users"]["response"];
+    };
+    listEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/emails"]["response"];
+    };
+    listFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following"]["response"];
+    };
+    listFollowersForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/followers"]["response"];
+    };
+    listFollowersForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/followers"]["response"];
+    };
+    listFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following"]["response"];
+    };
+    listGpgKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys"]["response"];
+    };
+    listGpgKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gpg_keys"]["response"];
+    };
+    listPublicEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/public_emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/public_emails"]["response"];
+    };
+    listPublicKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/keys"]["response"];
+    };
+    listPublicSshKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys"]["response"];
+    };
+    unfollow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/following/{username}"]["response"];
+    };
+    updateAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user"]["response"];
+    };
+  };
+};

--- a/src/generated/ghe-30-method-types.ts
+++ b/src/generated/ghe-30-method-types.ts
@@ -1,0 +1,7927 @@
+import { EndpointInterface, RequestInterface } from "@octokit/types";
+import { RestEndpointMethodTypes } from "./ghe-30-parameters-and-response-types";
+
+export type RestEndpointMethods = {
+  actions: {
+    /**
+     * Adds a repository to an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@3.0/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    addSelectedRepoToOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["addSelectedRepoToOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["addSelectedRepoToOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Cancels a workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    cancelWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["cancelWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["cancelWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates an organization secret with an encrypted value. Encrypt your secret using
+     * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
+     * token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to
+     * use this endpoint.
+     *
+     * #### Example encrypting a secret using Node.js
+     *
+     * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
+     *
+     * ```
+     * const sodium = require('tweetsodium');
+     *
+     * const key = "base64-encoded-public-key";
+     * const value = "plain-text-secret";
+     *
+     * // Convert the message and key to Uint8Array's (Buffer implements that interface)
+     * const messageBytes = Buffer.from(value);
+     * const keyBytes = Buffer.from(key, 'base64');
+     *
+     * // Encrypt using LibSodium.
+     * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+     *
+     * // Base64 the encrypted secret
+     * const encrypted = Buffer.from(encryptedBytes).toString('base64');
+     *
+     * console.log(encrypted);
+     * ```
+     *
+     *
+     * #### Example encrypting a secret using Python
+     *
+     * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
+     *
+     * ```
+     * from base64 import b64encode
+     * from nacl import encoding, public
+     *
+     * def encrypt(public_key: str, secret_value: str) -> str:
+     *   """Encrypt a Unicode string using the public key."""
+     *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+     *   sealed_box = public.SealedBox(public_key)
+     *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+     *   return b64encode(encrypted).decode("utf-8")
+     * ```
+     *
+     * #### Example encrypting a secret using C#
+     *
+     * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
+     *
+     * ```
+     * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
+     * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
+     *
+     * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+     *
+     * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+     * ```
+     *
+     * #### Example encrypting a secret using Ruby
+     *
+     * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
+     *
+     * ```ruby
+     * require "rbnacl"
+     * require "base64"
+     *
+     * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
+     * public_key = RbNaCl::PublicKey.new(key)
+     *
+     * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+     * encrypted_secret = box.encrypt("my_secret")
+     *
+     * # Print the base64 encoded secret
+     * puts Base64.strict_encode64(encrypted_secret)
+     * ```
+     */
+    createOrUpdateOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createOrUpdateOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createOrUpdateOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates a repository secret with an encrypted value. Encrypt your secret using
+     * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
+     * token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use
+     * this endpoint.
+     *
+     * #### Example encrypting a secret using Node.js
+     *
+     * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
+     *
+     * ```
+     * const sodium = require('tweetsodium');
+     *
+     * const key = "base64-encoded-public-key";
+     * const value = "plain-text-secret";
+     *
+     * // Convert the message and key to Uint8Array's (Buffer implements that interface)
+     * const messageBytes = Buffer.from(value);
+     * const keyBytes = Buffer.from(key, 'base64');
+     *
+     * // Encrypt using LibSodium.
+     * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+     *
+     * // Base64 the encrypted secret
+     * const encrypted = Buffer.from(encryptedBytes).toString('base64');
+     *
+     * console.log(encrypted);
+     * ```
+     *
+     *
+     * #### Example encrypting a secret using Python
+     *
+     * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
+     *
+     * ```
+     * from base64 import b64encode
+     * from nacl import encoding, public
+     *
+     * def encrypt(public_key: str, secret_value: str) -> str:
+     *   """Encrypt a Unicode string using the public key."""
+     *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+     *   sealed_box = public.SealedBox(public_key)
+     *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+     *   return b64encode(encrypted).decode("utf-8")
+     * ```
+     *
+     * #### Example encrypting a secret using C#
+     *
+     * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
+     *
+     * ```
+     * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
+     * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
+     *
+     * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+     *
+     * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+     * ```
+     *
+     * #### Example encrypting a secret using Ruby
+     *
+     * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
+     *
+     * ```ruby
+     * require "rbnacl"
+     * require "base64"
+     *
+     * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
+     * public_key = RbNaCl::PublicKey.new(key)
+     *
+     * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+     * encrypted_secret = box.encrypt("my_secret")
+     *
+     * # Print the base64 encoded secret
+     * puts Base64.strict_encode64(encrypted_secret)
+     * ```
+     */
+    createOrUpdateRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createOrUpdateRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createOrUpdateRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script. The token expires after one hour.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     *
+     * #### Example using registration token
+     *
+     * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh --url https://github.com/octo-org --token TOKEN
+     * ```
+     */
+    createRegistrationTokenForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRegistrationTokenForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRegistrationTokenForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script. The token expires after one hour. You must authenticate
+     * using an access token with the `repo` scope to use this endpoint.
+     *
+     * #### Example using registration token
+     *
+     * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh --url https://github.com/octo-org/octo-repo-artifacts --token TOKEN
+     * ```
+     */
+    createRegistrationTokenForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRegistrationTokenForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRegistrationTokenForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script to remove a self-hosted runner from an organization. The token expires after one hour.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     *
+     * #### Example using remove token
+     *
+     * To remove your self-hosted runner from an organization, replace `TOKEN` with the remove token provided by this
+     * endpoint.
+     *
+     * ```
+     * ./config.sh remove --token TOKEN
+     * ```
+     */
+    createRemoveTokenForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRemoveTokenForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRemoveTokenForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to remove a self-hosted runner from a repository. The token expires after one hour.
+     * You must authenticate using an access token with the `repo` scope to use this endpoint.
+     *
+     * #### Example using remove token
+     *
+     * To remove your self-hosted runner from a repository, replace TOKEN with the remove token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh remove --token TOKEN
+     * ```
+     */
+    createRemoveTokenForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRemoveTokenForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRemoveTokenForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to manually trigger a GitHub Actions workflow run. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must configure your GitHub Actions workflow to run when the [`workflow_dispatch` webhook](/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch) event occurs. The `inputs` are configured in the workflow file. For more information about how to configure the `workflow_dispatch` event in the workflow file, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#workflow_dispatch)."
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)."
+     */
+    createWorkflowDispatch: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes an artifact for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    deleteArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteArtifact"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteArtifact"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a secret in an organization using the secret name. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    deleteOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a secret in a repository using the secret name. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    deleteRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Forces the removal of a self-hosted runner from an organization. You can use this endpoint to completely remove the runner when the machine you were using no longer exists.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    deleteSelfHostedRunnerFromOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Forces the removal of a self-hosted runner from a repository. You can use this endpoint to completely remove the runner when the machine you were using no longer exists.
+     *
+     * You must authenticate using an access token with the `repo`
+     * scope to use this endpoint.
+     */
+    deleteSelfHostedRunnerFromRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a specific workflow run. Anyone with write access to the repository can use this endpoint. If the repository is
+     * private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:write` permission to use
+     * this endpoint.
+     */
+    deleteWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes all logs for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    deleteWorkflowRunLogs: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteWorkflowRunLogs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteWorkflowRunLogs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a repository from the list of selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    disableSelectedRepositoryGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["disableSelectedRepositoryGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["disableSelectedRepositoryGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Disables a workflow and sets the `state` of the workflow to `disabled_manually`. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    disableWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["disableWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["disableWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download an archive for a repository. This URL expires after 1 minute. Look for `Location:` in
+     * the response header to find the URL for the download. The `:archive_format` must be `zip`. Anyone with read access to
+     * the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+     * GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    downloadArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadArtifact"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadArtifact"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a plain text file of logs for a workflow job. This link expires after 1 minute. Look
+     * for `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can
+     * use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must
+     * have the `actions:read` permission to use this endpoint.
+     */
+    downloadJobLogsForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadJobLogsForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadJobLogsForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download an archive of log files for a workflow run. This link expires after 1 minute. Look for
+     * `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can use
+     * this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have
+     * the `actions:read` permission to use this endpoint.
+     */
+    downloadWorkflowRunLogs: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadWorkflowRunLogs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadWorkflowRunLogs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a repository to the list of selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    enableSelectedRepositoryGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["enableSelectedRepositoryGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["enableSelectedRepositoryGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables a workflow and sets the `state` of the workflow to `active`. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    enableWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["enableWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["enableWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the selected actions that are allowed in an organization. To use this endpoint, the organization permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization).""
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    getAllowedActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getAllowedActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getAllowedActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the settings for selected actions that are allowed in a repository. To use this endpoint, the repository policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for a repository](#set-github-actions-permissions-for-a-repository)."
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    getAllowedActionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getAllowedActionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getAllowedActionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific artifact for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getArtifact"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["actions"]["getArtifact"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the GitHub Actions permissions policy for repositories and allowed actions in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    getGithubActionsPermissionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the GitHub Actions permissions policy for a repository, including whether GitHub Actions is enabled and the actions allowed to run in the repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    getGithubActionsPermissionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific job in a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getJobForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getJobForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getJobForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    getOrgPublicKey: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getOrgPublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getOrgPublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a single organization secret without revealing its encrypted value. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    getOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    getRepoPublicKey: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getRepoPublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getRepoPublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a single repository secret without revealing its encrypted value. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    getRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific self-hosted runner configured in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    getSelfHostedRunnerForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific self-hosted runner configured in a repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint.
+     */
+    getSelfHostedRunnerForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific workflow. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getWorkflow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["actions"]["getWorkflow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all artifacts for a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listArtifactsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listArtifactsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listArtifactsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists jobs for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#parameters).
+     */
+    listJobsForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all secrets available in an organization without revealing their encrypted values. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    listOrgSecrets: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listOrgSecrets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listOrgSecrets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all secrets available in a repository without revealing their encrypted values. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    listRepoSecrets: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRepoSecrets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRepoSecrets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the workflows in a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listRepoWorkflows: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists binaries for the runner application that you can download and run.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    listRunnerApplicationsForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRunnerApplicationsForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRunnerApplicationsForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists binaries for the runner application that you can download and run.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint.
+     */
+    listRunnerApplicationsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRunnerApplicationsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRunnerApplicationsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all repositories that have been selected when the `visibility` for repository access to a secret is set to `selected`. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    listSelectedReposForOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelectedReposForOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelectedReposForOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    listSelectedRepositoriesEnabledGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelectedRepositoriesEnabledGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelectedRepositoriesEnabledGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all self-hosted runners configured in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    listSelfHostedRunnersForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all self-hosted runners configured in a repository. You must authenticate using an access token with the `repo` scope to use this endpoint.
+     */
+    listSelfHostedRunnersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists artifacts for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listWorkflowRunArtifacts: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRunArtifacts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRunArtifacts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all workflow runs for a workflow. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#parameters).
+     *
+     * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+     */
+    listWorkflowRuns: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRuns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRuns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all workflow runs for a repository. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#parameters).
+     *
+     * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listWorkflowRunsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Re-runs your workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    reRunWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["reRunWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["reRunWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a repository from an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@3.0/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    removeSelectedRepoFromOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["removeSelectedRepoFromOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["removeSelectedRepoFromOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the actions that are allowed in an organization. To use this endpoint, the organization permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * If the organization belongs to an enterprise that has `selected` actions set at the enterprise level, then you cannot override any of the enterprise's allowed actions settings.
+     *
+     * To use the `patterns_allowed` setting for private repositories, the organization must belong to an enterprise. If the organization does not belong to an enterprise, then the `patterns_allowed` setting only applies to public repositories in the organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    setAllowedActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setAllowedActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setAllowedActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the actions that are allowed in a repository. To use this endpoint, the repository permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for a repository](#set-github-actions-permissions-for-a-repository)."
+     *
+     * If the repository belongs to an organization or enterprise that has `selected` actions set at the organization or enterprise levels, then you cannot override any of the allowed actions settings.
+     *
+     * To use the `patterns_allowed` setting for private repositories, the repository must belong to an enterprise. If the repository does not belong to an enterprise, then the `patterns_allowed` setting only applies to public repositories.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    setAllowedActionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setAllowedActionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setAllowedActionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the GitHub Actions permissions policy for repositories and allowed actions in an organization.
+     *
+     * If the organization belongs to an enterprise that has set restrictive permissions at the enterprise level, such as `allowed_actions` to `selected` actions, then you cannot override them for the organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    setGithubActionsPermissionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the GitHub Actions permissions policy for enabling GitHub Actions and allowed actions in the repository.
+     *
+     * If the repository belongs to an organization or enterprise that has set restrictive permissions at the organization or enterprise levels, such as `allowed_actions` to `selected` actions, then you cannot override them for the repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    setGithubActionsPermissionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces all repositories for an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@3.0/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    setSelectedReposForOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setSelectedReposForOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setSelectedReposForOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces the list of selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    setSelectedRepositoriesEnabledGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setSelectedRepositoriesEnabledGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setSelectedRepositoriesEnabledGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#set-a-repository-subscription).
+     */
+    deleteRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Mutes all future notifications for a conversation until you comment on the thread or get an **@mention**. If you are watching the repository of the thread, you will still receive notifications. To ignore future notifications for a repository you are watching, use the [Set a thread subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#set-a-thread-subscription) endpoint and set `ignore` to `true`.
+     */
+    deleteThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * GitHub Enterprise Server provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:
+     *
+     * *   **Timeline**: The GitHub Enterprise Server global public timeline
+     * *   **User**: The public timeline for any user, using [URI template](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#hypermedia)
+     * *   **Current user public**: The public timeline for the authenticated user
+     * *   **Current user**: The private timeline for the authenticated user
+     * *   **Current user actor**: The private timeline for activity created by the authenticated user
+     * *   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
+     * *   **Security advisories**: A collection of public announcements that provide information about security-related vulnerabilities in software on GitHub Enterprise Server.
+     *
+     * **Note**: Private feeds are only returned when [authenticating via Basic Auth](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) since current feed URIs use the older, non revocable auth tokens.
+     */
+    getFeeds: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getFeeds"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getFeeds"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getThread: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThread"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getThread"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This checks to see if the current user is subscribed to a thread. You can also [get a repository subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#get-a-repository-subscription).
+     *
+     * Note that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mentioned**, or manually subscribe to a thread.
+     */
+    getThreadSubscriptionForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+     */
+    listEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user, sorted by most recently updated.
+     */
+    listNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This is the user's organization dashboard. You must be authenticated as the user to view this.
+     */
+    listOrgEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * We delay the public events feed by five minutes, which means the most recent event returned by the public events API actually occurred at least five minutes ago.
+     */
+    listPublicEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForRepoNetwork: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicOrgEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.
+     */
+    listReceivedEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReceivedPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRepoEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user.
+     */
+    listRepoNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user is watching.
+     */
+    listReposWatchedByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people that have starred the repository.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `Accept` header:
+     */
+    listStargazersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user is watching.
+     */
+    listWatchedReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people watching the specified repository.
+     */
+    listWatchersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications as "read" removes it from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List notifications for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#list-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications in a repository as "read" removes them from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List repository notifications for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#list-repository-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markRepoNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    markThreadAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markThreadAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markThreadAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#delete-a-repository-subscription) completely.
+     */
+    setRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are watching a repository, you receive notifications for all threads by default. Use this endpoint to ignore future notifications for threads until you comment on the thread or get an **@mention**.
+     *
+     * You can also use this endpoint to subscribe to threads that you are currently not receiving notifications for or to subscribed to threads that you have previously ignored.
+     *
+     * Unsubscribing from a conversation in a repository that you are not watching is functionally equivalent to the [Delete a thread subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#delete-a-thread-subscription) endpoint.
+     */
+    setThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    starRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstarRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  apps: {
+    /**
+     * Add a single repository to an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@3.0/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    addRepoToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) to use this endpoint, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.
+     */
+    checkToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["checkToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["checkToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated:** use `apps.createContentAttachmentForRepo()` (`POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments`) instead. Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://docs.github.com/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachment: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` and `repository` `full_name` of the content reference from the [`content_reference` event](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/enterprise-server@3.0/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachmentForRepo: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.
+     */
+    createFromManifest: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createFromManifest"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createFromManifest"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an installation access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token. By default the installation token has access to all repositories that the installation can access. To restrict the access to specific repositories, you can provide the `repository_ids` when creating the token. When you omit `repository_ids`, the response does not contain the `repositories` key.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    createInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid OAuth `access_token` as an input parameter and the grant for the token's owner will be deleted.
+     * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+     */
+    deleteAuthorization: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteAuthorization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteAuthorization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uninstalls a GitHub App on a user, organization, or business account. If you prefer to temporarily suspend an app's access to your account's resources, then we recommend the "[Suspend an app installation](https://docs.github.com/enterprise-server@3.0/rest/reference/apps/#suspend-an-app-installation)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    deleteInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+     */
+    deleteToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["deleteToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the "[List installations for the authenticated app](https://docs.github.com/enterprise-server@3.0/rest/reference/apps#list-installations-for-the-authenticated-app)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).
+     *
+     * If the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    getBySlug: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getBySlug"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["getBySlug"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find an installation's information using the installation id. The installation's account type (`target_type`) will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the organization's installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getOrgInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getOrgInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getOrgInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getRepoInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getRepoInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getRepoInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the user’s installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getUserInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getUserInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getUserInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the webhook configuration for a GitHub App. For more information about configuring a webhook for your app, see "[Creating a GitHub App](/developers/apps/creating-a-github-app)."
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getWebhookConfigForApp: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getWebhookConfigForApp"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getWebhookConfigForApp"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The access the user has to each repository is included in the hash under the `permissions` key.
+     */
+    listInstallationReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     *
+     * The permissions the installation has are included under the `permissions` key.
+     */
+    listInstallations: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You can find the permissions for the installation under the `permissions` key.
+     */
+    listInstallationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that an app installation can access.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    listReposAccessibleToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Remove a single repository from an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@3.0/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    removeRepoFromInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    resetToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["resetToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["resetToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Revokes the installation token you're using to authenticate as an installation and access this endpoint.
+     *
+     * Once an installation token is revoked, the token is invalidated and cannot be used. Other endpoints that require the revoked installation token must have a new installation token to work. You can create a new token using the "[Create an installation access token for an app](https://docs.github.com/enterprise-server@3.0/rest/reference/apps#create-an-installation-access-token-for-an-app)" endpoint.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    revokeInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use a non-scoped user-to-server OAuth access token to create a repository scoped and/or permission scoped user-to-server OAuth access token. You can specify which repositories the token can access and which permissions are granted to the token. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    scopeToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["scopeToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["scopeToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Suspends a GitHub App on a user, organization, or business account, which blocks the app from accessing the account's resources. When a GitHub App is suspended, the app's access to the GitHub Enterprise Server API or webhook events is blocked for that account.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    suspendInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["suspendInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["suspendInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GitHub App installation suspension.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    unsuspendInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["unsuspendInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["unsuspendInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the webhook configuration for a GitHub App. For more information about configuring a webhook for your app, see "[Creating a GitHub App](/developers/apps/creating-a-github-app)."
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    updateWebhookConfigForApp: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["updateWebhookConfigForApp"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["updateWebhookConfigForApp"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  checks: {
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Creates a new check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to create check runs.
+     *
+     * In a check suite, GitHub limits the number of check runs with the same name to 1000. Once these check runs exceed 1000, GitHub will start to automatically delete older check runs.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * By default, check suites are automatically created when you create a [check run](https://docs.github.com/enterprise-server@3.0/rest/reference/checks#check-runs). You only need to use this endpoint for manually creating check suites when you've disabled automatic creation using "[Update repository preferences for check suites](https://docs.github.com/enterprise-server@3.0/rest/reference/checks#update-repository-preferences-for-check-suites)". Your GitHub App must have the `checks:write` permission to create check suites.
+     */
+    createSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["createSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["createSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    getSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["getSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["getSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.
+     */
+    listAnnotations: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listAnnotations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listAnnotations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    listSuitesForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listSuitesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listSuitesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository. This endpoint will trigger the [`check_suite` webhook](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#check_suite) event with the action `rerequested`. When a check suite is `rerequested`, its `status` is reset to `queued` and the `conclusion` is cleared.
+     *
+     * To rerequest a check suite, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.
+     */
+    rerequestSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["rerequestSuite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["rerequestSuite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://docs.github.com/enterprise-server@3.0/rest/reference/checks#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.
+     */
+    setSuitesPreferences: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Updates a check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to edit check runs.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codeScanning: {
+    /**
+     * Gets a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` read permission to use this endpoint.
+     *
+     * **Deprecation notice**:
+     * The instances field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The same information can now be retrieved via a GET request to the URL specified by `instances_url`.
+     */
+    getAlert: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["getAlert"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["getAlert"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all open code scanning alerts for the default branch (usually `main`
+     * or `master`). You must use an access token with the `security_events` scope to use
+     * this endpoint. GitHub Apps must have the `security_events` read permission to use
+     * this endpoint.
+     *
+     * The response includes a `most_recent_instance` object.
+     * This provides details of the most recent instance of this alert
+     * for the default branch or for the specified Git reference
+     * (if you used `ref` in the request).
+     */
+    listAlertsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["listAlertsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["listAlertsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the details of all code scanning analyses for a repository,
+     * starting with the most recent.
+     * The response is paginated and you can use the `page` and `per_page` parameters
+     * to list the analyses you're interested in.
+     * By default 30 analyses are listed per page.
+     *
+     * The `rules_count` field in the response give the number of rules
+     * that were run in the analysis.
+     * For very old analyses this data is not available,
+     * and `0` is returned in this field.
+     *
+     * You must use an access token with the `security_events` scope to use this endpoint.
+     * GitHub Apps must have the `security_events` read permission to use this endpoint.
+     *
+     * **Deprecation notice**:
+     * The `tool_name` field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The tool name can now be found inside the `tool` field.
+     */
+    listRecentAnalyses: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["listRecentAnalyses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["listRecentAnalyses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the status of a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` write permission to use this endpoint.
+     */
+    updateAlert: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["updateAlert"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["updateAlert"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uploads SARIF data containing the results of a code scanning analysis to make the results available in a repository. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` write permission to use this endpoint.
+     *
+     * There are two places where you can upload code scanning results.
+     *  - If you upload to a pull request, for example `--ref refs/pull/42/merge` or `--ref refs/pull/42/head`, then the results appear as alerts in a pull request check. For more information, see "[Triaging code scanning alerts in pull requests](/code-security/secure-coding/triaging-code-scanning-alerts-in-pull-requests)."
+     *  - If you upload to a branch, for example `--ref refs/heads/my-branch`, then the results appear in the **Security** tab for your repository. For more information, see "[Managing code scanning alerts for your repository](/code-security/secure-coding/managing-code-scanning-alerts-for-your-repository#viewing-the-alerts-for-a-repository)."
+     *
+     * You must compress the SARIF-formatted analysis data that you want to upload, using `gzip`, and then encode it as a Base64 format string. For example:
+     *
+     * ```
+     * gzip -c analysis-data.sarif | base64 -w0
+     * ```
+     *
+     * SARIF upload supports a maximum of 1000 results per analysis run. Any results over this limit are ignored. Typically, but not necessarily, a SARIF file contains a single run of a single tool. If a code scanning tool generates too many results, you should update the analysis configuration to run only the most important rules or queries.
+     *
+     * The `202 Accepted`, response includes an `id` value.
+     * You can use this ID to check the status of the upload by using this for the `/sarifs/{sarif_id}` endpoint.
+     * For more information, see "[Get information about a SARIF upload](/rest/reference/code-scanning#get-information-about-a-sarif-upload)."
+     */
+    uploadSarif: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["uploadSarif"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["uploadSarif"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getConductCode: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  emojis: {
+    /**
+     * Lists all the emojis available to use on GitHub Enterprise Server.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["emojis"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["emojis"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you boot a GitHub instance for the first time, you can use the following endpoint to upload a license:
+     *
+     * Note that you need to POST to [`/setup/api/configure`](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#start-a-configuration-process) to start the actual configuration process.
+     *
+     * When using this endpoint, your GitHub instance must have a password set. This can be accomplished two ways:
+     *
+     * 1.  If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
+     * 2.  If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
+     *
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#get-settings).
+     */
+    createEnterpriseServerLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If an external authentication mechanism is used, the login name should match the login name in the external system. If you are using LDAP authentication, you should also [update the LDAP mapping](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#update-ldap-mapping-for-a-user) for the user.
+     *
+     * The login name will be normalized to only contain alphanumeric characters or single hyphens. For example, if you send `"octo_cat"` as the login, a user named `"octo-cat"` will be created.
+     *
+     * If the login name or email address is already associated with an account, the server will return a `422` response.
+     */
+    createUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a personal access token. Returns a `403 - Forbidden` status when a personal access token is in use. For example, if you access this endpoint with the same personal access token that you are trying to delete, you will receive this error.
+     */
+    deletePersonalAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you attempt to delete an environment that cannot be deleted, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * *   _Cannot modify or delete the default environment_
+     * *   _Cannot delete environment that has hooks_
+     * *   _Cannot delete environment when download is in progress_
+     */
+    deletePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePublicKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a user will delete all their repositories, gists, applications, and personal settings. [Suspending a user](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#suspend-a-user) is often a better option.
+     *
+     * You can delete any user account except your own.
+     */
+    deleteUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can demote any user account except your own.
+     */
+    demoteSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization from the list of selected organizations that are enabled for GitHub Actions in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    disableSelectedOrganizationGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["disableSelectedOrganizationGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["disableSelectedOrganizationGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The possible values for `enabled` are `true` and `false`. When it's `false`, the attribute `when` is ignored and the maintenance mode is turned off. `when` defines the time period when the maintenance was enabled.
+     *
+     * The possible values for `when` are `now` or any date parseable by [mojombo/chronic](https://github.com/mojombo/chronic).
+     */
+    enableOrDisableMaintenanceMode: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization to the list of selected organizations that are enabled for GitHub Actions in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    enableSelectedOrganizationGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableSelectedOrganizationGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableSelectedOrganizationGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllAuthorizedSshKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the selected actions that are allowed in an enterprise. To use this endpoint, the enterprise permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    getAllowedActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllowedActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllowedActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the current message and expiration date of the global announcement banner in your enterprise.
+     */
+    getAnnouncement: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAnnouncement"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAnnouncement"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommentStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getCommentStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to check the status of the most recent configuration process:
+     *
+     * Note that you may need to wait several seconds after you start a process before you can check its status.
+     *
+     * The different statuses are:
+     *
+     * | Status        | Description                       |
+     * | ------------- | --------------------------------- |
+     * | `PENDING`     | The job has not started yet       |
+     * | `CONFIGURING` | The job is running                |
+     * | `DONE`        | The job has finished correctly    |
+     * | `FAILED`      | The job has finished unexpectedly |
+     */
+    getConfigurationStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In addition to seeing the download status at the "[Get a pre-receive environment](#get-a-pre-receive-environment)" endpoint, there is also this separate endpoint for just the download status.
+     */
+    getDownloadStatusForPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the GitHub Actions permissions policy for organizations and allowed actions in an enterprise.
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    getGithubActionsPermissionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGithubActionsPermissionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGithubActionsPermissionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getHooksStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getHooksStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getIssueStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getIssueStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLicenseInformation: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Check your installation's maintenance status:
+     */
+    getMaintenanceStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestoneStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMilestoneStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getOrgStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getOrgStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPagesStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPullRequestStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPullRequestStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getRepoStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getUserStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getUserStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listGlobalWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists personal access tokens for all users, including admin users.
+     */
+    listPersonalAccessTokens: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveEnvironments: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveHooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this organization as well as any disabled hooks that can be configured at the organization level. Globally disabled pre-receive hooks that do not allow downstream configuration are not listed.
+     */
+    listPreReceiveHooksForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this repository as well as any disabled hooks that are allowed to be enabled at the repository level. Pre-receive hooks that are disabled at a higher level and are not configurable will not be listed.
+     */
+    listPreReceiveHooksForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organizations that are selected to have GitHub Actions enabled in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    listSelectedOrganizationsEnabledGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listSelectedOrganizationsEnabledGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listSelectedOrganizationsEnabledGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@3.0/webhooks/#ping-event) to be sent to the webhook.
+     */
+    pingGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    promoteUserToBeSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the global announcement banner in your enterprise.
+     */
+    removeAnnouncement: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAnnouncement"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAnnouncement"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any overrides for this hook at the org level for this org.
+     */
+    removePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes any overridden enforcement on this repository for the specified hook.
+     *
+     * Responds with effective values inherited from owner and/or global level.
+     */
+    removePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the actions that are allowed in an enterprise. To use this endpoint, the enterprise permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    setAllowedActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setAllowedActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setAllowedActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the message and expiration time for the global announcement banner in your enterprise.
+     */
+    setAnnouncement: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setAnnouncement"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setAnnouncement"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the GitHub Actions permissions policy for organizations and allowed actions in an enterprise.
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    setGithubActionsPermissionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setGithubActionsPermissionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setGithubActionsPermissionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces the list of selected organizations that are enabled for GitHub Actions in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    setSelectedOrganizationsEnabledGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSelectedOrganizationsEnabledGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSelectedOrganizationsEnabledGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#get-settings).
+     */
+    setSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to start a configuration process at any time for your updated settings to take effect:
+     */
+    startConfigurationProcess: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers a new download of the environment tarball from the environment's `image_url`. When the download is finished, the newly downloaded tarball will overwrite the existing environment.
+     *
+     * If a download cannot be triggered, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * * _Cannot modify or delete the default environment_
+     * * _Can not start a new download when a download is in progress_
+     */
+    startPreReceiveEnvironmentDownload: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), Active Directory LDAP-authenticated users cannot be suspended through this API. If you attempt to suspend an Active Directory LDAP-authenticated user through this API, it will return a `403` response.
+     *
+     * You can suspend any user account except your own.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    suspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), this API is disabled and will return a `403` response. Active Directory LDAP-authenticated users cannot be unsuspended using the API.
+     */
+    unsuspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Parameters that are not provided will be overwritten with the default value or removed if no default exists.
+     */
+    updateGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the [distinguished name](https://www.ldap.com/ldap-dns-and-rdns) (DN) of the LDAP entry to map to a team. [LDAP synchronization](https://help.github.com/enterprise/admin/guides/user-management/using-ldap/#enabling-ldap-sync) must be enabled to map LDAP entries to a team. Use the [Create a team](https://docs.github.com/enterprise-server@3.0/rest/reference/teams/#create-a-team) endpoint to create a team with LDAP mapping.
+     *
+     * If you pass the `hellcat-preview` media type, you can also update the LDAP mapping of a child team.
+     */
+    updateLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateOrgName: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You cannot modify the default environment. If you attempt to modify the default environment, you will receive a `422 Unprocessable Entity` response.
+     */
+    updatePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updatePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the org level, you can set `enforcement` and `allow_downstream_configuration`
+     */
+    updatePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the repo level, you can set `enforcement`
+     */
+    updatePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateUsernameForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This API upgrades your license and also triggers the configuration process:
+     */
+    upgradeLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["checkIsStarred"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gists"]["checkIsStarred"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to add a new gist with one or more files.
+     *
+     * **Note:** Don't name your files "gistfile" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["createComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["createComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["deleteComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["deleteComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: This was previously `/gists/:gist_id/fork`.
+     */
+    fork: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["fork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["fork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    get: {
+      (params?: RestEndpointMethodTypes["gists"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["gists"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRevision: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getRevision"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getRevision"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the authenticated user's gists or if called anonymously, this endpoint returns all public gists:
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public gists for the specified user:
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List public gists sorted by most recently updated to least recently updated.
+     *
+     * Note: With [pagination](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the authenticated user's starred gists:
+     */
+    listStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listStarred"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listStarred"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    star: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["star"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["star"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstar: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["unstar"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["unstar"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to update or delete a gist file and rename gist files. Files from the previous version of the gist that aren't explicitly changed during an edit are unchanged.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["updateComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["updateComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  git: {
+    createBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reference for your repository. You are unable to create new references for empty repositories, even if the commit SHA-1 hash used exists. Empty repositories are repositories without branches.
+     */
+    createRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://docs.github.com/enterprise-server@3.0/rest/reference/git#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://docs.github.com/enterprise-server@3.0/rest/reference/git#create-a-reference) the tag reference - this call would be unnecessary.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The tree creation API accepts nested entries. If you specify both a tree and a nested path modifying that tree, this endpoint will overwrite the contents of the tree with the new path contents, and create a new tree structure.
+     *
+     * If you use this endpoint to add, delete, or modify the file contents in a tree, you will need to commit the tree and then update a branch to point to the commit. For more information see "[Create a commit](https://docs.github.com/enterprise-server@3.0/rest/reference/git#create-a-commit)" and "[Update a reference](https://docs.github.com/enterprise-server@3.0/rest/reference/git#update-a-reference)."
+     */
+    createTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["deleteRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["deleteRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `content` in the response will always be Base64 encoded.
+     *
+     * _Note_: This API supports blobs up to 100 megabytes in size.
+     */
+    getBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single reference from your Git database. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't match an existing ref, a `404` is returned.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@3.0/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     */
+    getRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single tree using the SHA1 value for that tree.
+     *
+     * If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+     */
+    getTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns an array of references from your Git database that match the supplied name. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't exist in the repository, but existing refs start with `:ref`, they will be returned as an array.
+     *
+     * When you use this endpoint without providing a `:ref`, it will return an array of all the references from your Git database, including notes and stashes if they exist on the server. Anything in the namespace is returned, not just `heads` and `tags`.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@3.0/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * If you request matching references for a branch named `feature` but the branch `feature` doesn't exist, the response can still include other matching head refs that start with the word `feature`, such as `featureA` and `featureB`.
+     */
+    listMatchingRefs: {
+      (
+        params?: RestEndpointMethodTypes["git"]["listMatchingRefs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["git"]["listMatchingRefs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["updateRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["updateRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gitignore: {
+    /**
+     * List all templates available to pass as an option when [creating a repository](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#create-a-repository-for-the-authenticated-user).
+     */
+    getAllTemplates: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API also allows fetching the source of a single template.
+     * Use the raw [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) to get the raw contents.
+     */
+    getTemplate: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  issues: {
+    /**
+     * Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.
+     */
+    addAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addAssignees"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addAssignees"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    addLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks if a user has permission to be assigned to an issue in this repository.
+     *
+     * If the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.
+     *
+     * Otherwise a `404` status code is returned.
+     */
+    checkUserCanBeAssigned: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://help.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["createLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["deleteLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API returns a [`301 Moved Permanently` status](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-redirects-redirects) if the issue was
+     * [transferred](https://help.github.com/articles/transferring-an-issue-to-another-repository/) to another repository. If
+     * the issue was transferred to or deleted from a repository where the authenticated user lacks read access, the API
+     * returns a `404 Not Found` status. If the issue was deleted from a repository where the authenticated user has read
+     * access, the API returns a `410 Gone` status. To receive webhook events for transferred and deleted issues, subscribe
+     * to the [`issues`](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#issues) webhook.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getEvent: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getEvent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getEvent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getMilestone"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getMilestone"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues assigned to the authenticated user across all visible repositories including owned repositories, member
+     * repositories, and organization repositories. You can use the `filter` query parameter to fetch issues that are not
+     * necessarily assigned to you.
+     *
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.
+     */
+    listAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue Comments are ordered by ascending ID.
+     */
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * By default, Issue Comments are ordered by ascending ID.
+     */
+    listCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEvents: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEvents"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listEvents"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForTimeline: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues across owned and member repositories assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in an organization assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in a repository.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsOnIssue: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMilestones: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listMilestones"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listMilestones"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can lock an issue or pull request's conversation.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    lock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["lock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["lock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAllLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAllLabels"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAllLabels"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes one or more assignees from an issue.
+     */
+    removeAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the specified label from the issue, and returns the remaining labels on the issue. This endpoint returns a `404 Not Found` status if the label does not exist.
+     */
+    removeLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["removeLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any previous labels and sets the new labels for an issue.
+     */
+    setLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["setLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["setLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can unlock an issue's conversation.
+     */
+    unlock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["unlock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["unlock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue owners and users with push access can edit an issue.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  licenses: {
+    get: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllCommonlyUsed: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This method returns the contents of the repository's license file, if one is detected.
+     *
+     * Similar to [Get repository content](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#get-repository-content), this method also supports [custom media types](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types) for retrieving the raw license content or rendered license HTML.
+     */
+    getForRepo: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["getForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  markdown: {
+    render: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["render"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["render"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.
+     */
+    renderRaw: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["renderRaw"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["renderRaw"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  meta: {
+    get: {
+      (params?: RestEndpointMethodTypes["meta"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get the octocat as ASCII art
+     */
+    getOctocat: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getOctocat"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getOctocat"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a random sentence from the Zen of GitHub
+     */
+    getZen: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getZen"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getZen"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get Hypermedia links to resources accessible in GitHub's REST API
+     */
+    root: {
+      (params?: RestEndpointMethodTypes["meta"]["root"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["root"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  orgs: {
+    /**
+     * Check if a user is, publicly or privately, a member of the organization.
+     */
+    checkMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPublicMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see "[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)".
+     */
+    convertMemberToOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Here's how you can create a hook that posts payloads in JSON format:
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
+     *
+     * GitHub Apps with the `Organization plan` permission can use this endpoint to retrieve information about an organization's GitHub Enterprise Server plan. See "[Authenticating with GitHub Apps](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/)" for details. For an example response, see 'Response with GitHub Enterprise Server plan information' below."
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["orgs"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to get a user's membership with an organization, the authenticated user must be an organization member. The `state` parameter in the response can be used to identify the user's membership status.
+     */
+    getMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in an organization. To get only the webhook `config` properties, see "[Get a webhook configuration for an organization](/rest/reference/orgs#get-a-webhook-configuration-for-an-organization)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the webhook configuration for an organization. To get more information about the webhook, including the `active` state and `events`, use "[Get an organization webhook ](/rest/reference/orgs#get-an-organization-webhook)."
+     *
+     * Access tokens must have the `admin:org_hook` scope, and GitHub Apps must have the `organization_hooks:read` permission.
+     */
+    getWebhookConfigForOrg: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhookConfigForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getWebhookConfigForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all organizations, in the order that they were created on GitHub Enterprise Server.
+     *
+     * **Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of organizations.
+     */
+    list: {
+      (params?: RestEndpointMethodTypes["orgs"]["list"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["list"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all GitHub Apps in an organization. The installation count includes all GitHub Apps installed on repositories in the organization. You must be an organization owner with `admin:read` scope to use this endpoint.
+     */
+    listAppInstallations: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listAppInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listAppInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List organizations for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * This only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.
+     *
+     * This method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List organizations for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/orgs#list-organizations-for-the-authenticated-user) API instead.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
+     */
+    listMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembers"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listMembers"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMembershipsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are outside collaborators of an organization.
+     */
+    listOutsideCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Members of an organization can choose to have their membership publicized or not.
+     */
+    listPublicMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listPublicMembers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listPublicMembers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@3.0/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+     */
+    removeMember: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMember"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["removeMember"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to remove a user's membership with an organization, the authenticated user must be an organization owner.
+     *
+     * If the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.
+     */
+    removeMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all the organization's repositories.
+     */
+    removeOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removePublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Only authenticated organization owners can add a member to the organization or update the member's role.
+     *
+     * *   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](https://docs.github.com/enterprise-server@3.0/rest/reference/orgs#get-organization-membership-for-a-user) will be `pending` until they accept the invitation.
+     *
+     * *   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.
+     */
+    setMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The user can publicize their own membership. (A user cannot publicize the membership for another user.)
+     *
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    setPublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Parameter Deprecation Notice:** GitHub Enterprise Server will replace and discontinue `members_allowed_repository_creation_type` in favor of more granular permissions. The new input parameters are `members_can_create_public_repositories`, `members_can_create_private_repositories` for all organizations and `members_can_create_internal_repositories` for organizations associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. For more information, see the [blog post](https://developer.github.com/changes/2019-12-03-internal-visibility-changes).
+     *
+     * Enables an authenticated organization owner with the `admin:org` scope to update the organization's profile and member privileges.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in an organization. When you update a webhook, the `secret` will be overwritten. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for an organization](/rest/reference/orgs#update-a-webhook-configuration-for-an-organization)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the webhook configuration for an organization. To update more information about the webhook, including the `active` state and `events`, use "[Update an organization webhook ](/rest/reference/orgs#update-an-organization-webhook)."
+     *
+     * Access tokens must have the `admin:org_hook` scope, and GitHub Apps must have the `organization_hooks:write` permission.
+     */
+    updateWebhookConfigForOrg: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhookConfigForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateWebhookConfigForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  projects: {
+    /**
+     * Adds a collaborator to an organization project and sets their permission level. You must be an organization owner or a project `admin` to add a collaborator.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["createCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an organization project board. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a repository project board. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a project board. Returns a `404 Not Found` status if projects are disabled.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["deleteCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["deleteColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a project by its `id`. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the collaborator's permission level for an organization project. Possible values for the `permission` key: `admin`, `write`, `read`, `none`. You must be an organization owner or a project `admin` to review a user's permission level.
+     */
+    getPermissionForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getPermissionForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["getPermissionForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCards: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCards"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listCards"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listColumns: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listColumns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listColumns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a collaborator from an organization project. You must be an organization owner or a project `admin` to remove a collaborator.
+     */
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a project board's information. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["updateCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["updateColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["checkIfMerged"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["checkIfMerged"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+     *
+     * You can create a new pull request.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reply to a review comment for a pull request. For the `comment_id`, provide the ID of the review comment you are replying to. This must be the ID of a _top-level review comment_, not a reply to that comment. Replies to replies are not supported.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReplyForReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * Pull request reviews created in the `PENDING` state do not include the `submitted_at` property in the response.
+     *
+     * **Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#get-a-pull-request) endpoint.
+     *
+     * The `position` value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     */
+    createReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["createReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a review comment in the pull request diff. To add a regular comment to a pull request timeline, see "[Create an issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#create-an-issue-comment)." We recommend creating a review comment using `line`, `side`, and optionally `start_line` and `start_side` if your comment applies to more than one line in the pull request diff.
+     *
+     * You can still create a review comment using the `position` parameter. When you use `position`, the `line`, `side`, `start_line`, and `start_side` parameters are not required. For more information, see the [`comfort-fade` preview notice](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#create-a-review-comment-for-a-pull-request-preview-notices).
+     *
+     * **Note:** The position value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePendingReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deletePendingReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deletePendingReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a review comment.
+     */
+    deleteReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** To dismiss a pull request review on a [protected branch](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#branches), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.
+     */
+    dismissReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["dismissReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["dismissReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists details of a pull request by providing its number.
+     *
+     * When you get, [create](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls/#create-a-pull-request), or [edit](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#update-a-pull-request) a pull request, GitHub Enterprise Server creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@3.0/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub Enterprise Server has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the _test_ merge commit.
+     *
+     * The value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
+     *
+     * *   If merged as a [merge commit](https://help.github.com/articles/about-merge-methods-on-github/), `merge_commit_sha` represents the SHA of the merge commit.
+     * *   If merged via a [squash](https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits), `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
+     * *   If [rebased](https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits), `merge_commit_sha` represents the commit that the base branch was updated to.
+     *
+     * Pass the appropriate [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["pulls"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["pulls"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["getReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides details for a review comment.
+     */
+    getReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["getReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List comments for a specific pull request review.
+     */
+    listCommentsForReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a maximum of 250 commits for a pull request. To receive a complete commit list for pull requests with more than 250 commits, use the [List commits](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-commits) endpoint.
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** Responses include a maximum of 3000 files. The paginated response returns 30 files per page by default.
+     */
+    listFiles: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listFiles"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
+     */
+    listReviewComments: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewComments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
+     */
+    listReviewCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The list of reviews returns in chronological order.
+     */
+    listReviews: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviews"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@3.0/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@3.0/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    requestReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["requestReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["requestReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    submitReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["submitReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["submitReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch.
+     */
+    updateBranch: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Update the review summary comment with new text.
+     */
+    updateReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables you to edit a review comment.
+     */
+    updateReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["updateReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  rateLimit: {
+    /**
+     * **Note:** Accessing this endpoint does not count against your REST API rate limit.
+     *
+     * **Note:** The `rate` object is deprecated. If you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["rateLimit"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["rateLimit"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  reactions: {
+    /**
+     * Create a reaction to a [commit comment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#comments). A response with an HTTP `200` status means that you already added the reaction type to this commit comment.
+     */
+    createForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue](https://docs.github.com/enterprise-server@3.0/rest/reference/issues/). A response with an HTTP `200` status means that you already added the reaction type to this issue.
+     */
+    createForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#comments). A response with an HTTP `200` status means that you already added the reaction type to this issue comment.
+     */
+    createForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#comments). A response with an HTTP `200` status means that you already added the reaction type to this pull request review comment.
+     */
+    createForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion comment.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    createForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    createForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [commit comment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#comments).
+     */
+    deleteForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/issues/:issue_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue](https://docs.github.com/enterprise-server@3.0/rest/reference/issues/).
+     */
+    deleteForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE delete /repositories/:repository_id/issues/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#comments).
+     */
+    deleteForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/pulls/comments/:comment_id/reactions/:reaction_id.`
+     *
+     * Delete a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#review-comments).
+     */
+    deleteForPullRequestComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Reactions API. We recommend migrating your existing code to use the new delete reactions endpoints. For more information, see this [blog post](https://developer.github.com/changes/2020-02-26-new-delete-reactions-endpoints/).
+     *
+     * OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), when deleting a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions) or [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments).
+     * @deprecated octokit.rest.reactions.deleteLegacy() is deprecated, see https://docs.github.com/enterprise-server@3.0/rest/reference/reactions/#delete-a-reaction-legacy
+     */
+    deleteLegacy: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteLegacy"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteLegacy"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [commit comment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#comments).
+     */
+    listForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue](https://docs.github.com/enterprise-server@3.0/rest/reference/issues).
+     */
+    listForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#comments).
+     */
+    listForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [pull request review comment](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#review-comments).
+     */
+    listForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments/). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    listForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    listForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["acceptInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["acceptInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified apps push access for this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * For more information the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * The invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#invitations).
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    addStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified teams push access for this branch. You can also give push access to child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified people push access for this branch.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    checkCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["checkCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["checkCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated**: Use `repos.compareCommitsWithBasehead()` (`GET /repos/{owner}/{repo}/compare/{basehead}`) instead. Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * To process a response with a large number of commits, you can use (`per_page` or `page`) to paginate the results. When using paging, the list of changed files is only returned with page 1, but includes all changed files for the entire comparison. For more information on working with pagination, see "[Traversing with pagination](/rest/guides/traversing-with-pagination)."
+     *
+     * When calling this API without any paging parameters (`per_page` or `page`), the returned list is limited to 250 commits and the last commit in the list is the most recent of the entire comparison. When a paging parameter is specified, the first commit in the returned list of each page is the earliest.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommits"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommits"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `basehead` param is comprised of two parts: `base` and `head`. Both must be branch names in `repo`. To compare branches across other repositories in the same network as `repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * The response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [List commits](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-commits) to enumerate all commits in the range.
+     *
+     * For comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long
+     * to generate. You can typically resolve this error by using a smaller commit range.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommitsWithBasehead: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a comment for a commit using its `:commit_sha`.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to require signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    createCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access in a repository can create commit statuses for a given SHA.
+     *
+     * Note: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.
+     */
+    createCommitStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can create a read-only deploy key.
+     */
+    createDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deployments offer a few configurable parameters with certain defaults.
+     *
+     * The `ref` parameter can be any named branch, tag, or SHA. At GitHub Enterprise Server we often deploy branches and verify them
+     * before we merge a pull request.
+     *
+     * The `environment` parameter allows deployments to be issued to different runtime environments. Teams often have
+     * multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This parameter
+     * makes it easier to track which environments have requested deployments. The default environment is `production`.
+     *
+     * The `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If
+     * the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds,
+     * the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will
+     * return a failure response.
+     *
+     * By default, [commit statuses](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#statuses) for every submitted context must be in a `success`
+     * state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to
+     * specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do
+     * not require any contexts or create any commit statuses, the deployment will always succeed.
+     *
+     * The `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text
+     * field that will be passed on when a deployment event is dispatched.
+     *
+     * The `task` parameter is used by the deployment system to allow different execution paths. In the web world this might
+     * be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an
+     * application with debugging enabled.
+     *
+     * Users with `repo` or `repo_deployment` scopes can create a deployment for a given ref.
+     *
+     * #### Merged branch response
+     * You will see this response when GitHub automatically merges the base branch into the topic branch instead of creating
+     * a deployment. This auto-merge happens when:
+     * *   Auto-merge option is enabled in the repository
+     * *   Topic branch does not include the latest changes on the base branch, which is `master` in the response example
+     * *   There are no merge conflicts
+     *
+     * If there are no new commits in the base branch, a new request to create a deployment should give a successful
+     * response.
+     *
+     * #### Merge conflict response
+     * This error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't
+     * be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.
+     *
+     * #### Failed commit status checks
+     * This error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success`
+     * status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.
+     */
+    createDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with `push` access can create deployment statuses for a given deployment.
+     *
+     * GitHub Apps require `read & write` access to "Deployments" and `read-only` access to "Repo contents" (for private repos). OAuth Apps require the `repo_deployment` scope.
+     */
+    createDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to trigger a webhook event called `repository_dispatch` when you want activity that happens outside of GitHub Enterprise Server to trigger a GitHub Actions workflow or GitHub App webhook. You must configure your GitHub Actions workflow or GitHub App to run when the `repository_dispatch` event occurs. For an example `repository_dispatch` webhook payload, see "[RepositoryDispatchEvent](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#repository_dispatch)."
+     *
+     * The `client_payload` parameter is available for any extra information that your workflow might need. This parameter is a JSON payload that will be passed on when the webhook event is dispatched. For example, the `client_payload` can include a message that a user would like to send using a GitHub Actions workflow. Or the `client_payload` can be used as a test to debug your workflow.
+     *
+     * This endpoint requires write access to the repository by providing either:
+     *
+     *   - Personal access tokens with `repo` scope. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)" in the GitHub Help documentation.
+     *   - GitHub Apps with both `metadata:read` and `contents:read&write` permissions.
+     *
+     * This input example shows how you can use the `client_payload` as a test to debug your workflow.
+     */
+    createDispatchEvent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDispatchEvent"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDispatchEvent"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository.
+     */
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a fork for the authenticated user.
+     *
+     * **Note**: Forking a Repository happens asynchronously. You may have to wait a short period of time before you can access the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub Enterprise Server Support](https://support.github.com/contact) or [GitHub Enterprise Server Premium Support](https://premium.githubsupport.com).
+     */
+    createFork: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createFork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createFork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository in the specified organization. The authenticated user must be a member of the organization.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createInOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new file or replaces an existing file in a repository.
+     */
+    createOrUpdateFileContents: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Configures a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages)."
+     */
+    createPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can create a release.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository using a repository template. Use the `template_owner` and `template_repo` route parameters to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the [Get a repository](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#get-a-repository) endpoint and check that the `is_template` key is `true`.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createUsingTemplate: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createUsingTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createUsingTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can
+     * share the same `config` as long as those webhooks do not have any `events` that overlap.
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    declineInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["declineInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["declineInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+     *
+     * If an organization owner has configured the organization to prevent members from deleting organization-owned
+     * repositories, you will get a `403 Forbidden` response.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Disables the ability to restrict who can push to this branch.
+     */
+    deleteAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    deleteAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deleteBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to disable required signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    deleteCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
+     */
+    deleteDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To ensure there can always be an active deployment, you can only delete an _inactive_ deployment. Anyone with `repo` or `repo_deployment` scopes can delete an inactive deployment.
+     *
+     * To set a deployment as inactive, you must:
+     *
+     * *   Create a new deployment that is active so that the system has a record of the current state, then delete the previously active deployment.
+     * *   Mark the active deployment as inactive by adding any non-successful deployment status.
+     *
+     * For more information, see "[Create a deployment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos/#create-a-deployment)" and "[Create a deployment status](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#create-a-deployment-status)."
+     */
+    deleteDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a file in a repository.
+     *
+     * You can provide an additional `committer` parameter, which is an object containing information about the committer. Or, you can provide an `author` parameter, which is an object containing information about the author.
+     *
+     * The `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.
+     *
+     * You must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.
+     */
+    deleteFile: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteFile"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteFile"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deletePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can delete a release.
+     */
+    deleteRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a tar archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadTarballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a zip archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadZipballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you pass the `scarlet-witch-preview` media type, requests to get a repository will also return the repository's code of conduct if it can be detected from the repository's code of conduct file.
+     *
+     * The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["repos"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["repos"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists who has access to this protected branch.
+     *
+     * **Note**: Users, apps, and teams `restrictions` are only available for organization-owned repositories.
+     */
+    getAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAllStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllTopics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getAllTopics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the GitHub Apps that have push access to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     */
+    getAppsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+     */
+    getCodeFrequencyStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks the repository permission of a collaborator. The possible repository permissions are `admin`, `write`, `read`, and `none`.
+     */
+    getCollaboratorPermissionLevel: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
+     *
+     * The most recent status for each context is returned, up to 100. This field [paginates](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination) if there are over 100 contexts.
+     *
+     * Additionally, a combined `state` is returned. The `state` is one of:
+     *
+     * *   **failure** if any of the contexts report as `error` or `failure`
+     * *   **pending** if there are no statuses or a context is `pending`
+     * *   **success** if the latest status for all contexts is `success`
+     */
+    getCombinedStatusForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the contents of a single commit reference. You must have `read` access for the repository to use this endpoint.
+     *
+     * **Note:** If there are more than 300 files in the commit diff, the response will include pagination link headers for the remaining files, up to a limit of 3000 files. Each page contains the static commit information, and the only changes are to the file listing.
+     *
+     * You can pass the appropriate [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to  fetch `diff` and `patch` formats. Diffs with binary data will have no `patch` property.
+     *
+     * To return only the SHA-1 hash of the commit reference, you can provide the `sha` custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) in the `Accept` header. You can use this endpoint to check if a remote reference's SHA-1 hash is the same as your local reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.
+     */
+    getCommitActivityStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to check whether a branch requires signed commits. An enabled status of `true` indicates you must sign commits on this branch. For more information, see [Signing commits with GPG](https://help.github.com/articles/signing-commits-with-gpg) in GitHub Help.
+     *
+     * **Note**: You must enable branch protection to require signed commits.
+     */
+    getCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the contents of a file or directory in a repository. Specify the file path or directory in `:path`. If you omit
+     * `:path`, you will receive the contents of the repository's root directory. See the description below regarding what the API response includes for directories.
+     *
+     * Files and symlinks support [a custom media type](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) for
+     * retrieving the raw content or rendered HTML (when supported). All content types support [a custom media
+     * type](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) to ensure the content is returned in a consistent
+     * object format.
+     *
+     * **Note**:
+     * *   To get a repository's contents recursively, you can [recursively get the tree](https://docs.github.com/enterprise-server@3.0/rest/reference/git#trees).
+     * *   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees
+     * API](https://docs.github.com/enterprise-server@3.0/rest/reference/git#get-a-tree).
+     * *   This API supports files up to 1 megabyte in size.
+     *
+     * #### If the content is a directory
+     * The response will be an array of objects, one object for each item in the directory.
+     * When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value
+     * _should_ be "submodule". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW).
+     * In the next major version of the API, the type will be returned as "submodule".
+     *
+     * #### If the content is a symlink
+     * If the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the
+     * API responds with the content of the file (in the format shown in the example. Otherwise, the API responds with an object
+     * describing the symlink itself.
+     *
+     * #### If the content is a submodule
+     * The `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific
+     * commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out
+     * the submodule at that specific commit.
+     *
+     * If the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links["git"]`) and the
+     * github.com URLs (`html_url` and `_links["html"]`) will have null values.
+     */
+    getContent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getContent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the `total` number of commits authored by the contributor. In addition, the response includes a Weekly Hash (`weeks` array) with the following information:
+     *
+     * *   `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+     * *   `a` - Number of additions
+     * *   `d` - Number of deletions
+     * *   `c` - Number of commits
+     */
+    getContributorsStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContributorsStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getContributorsStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployKey"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployKey"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view a deployment status for a deployment:
+     */
+    getDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLatestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View the latest published full release for the repository.
+     *
+     * The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
+     */
+    getLatestRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestRelease"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestRelease"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPagesBuild"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPagesBuild"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.
+     *
+     * The array order is oldest week (index 0) to most recent week.
+     */
+    getParticipationStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getParticipationStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getParticipationStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getPullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Each array contains the day number, hour number, and number of commits:
+     *
+     * *   `0-6`: Sunday - Saturday
+     * *   `0-23`: Hour of day
+     * *   Number of commits
+     *
+     * For example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+     */
+    getPunchCardStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPunchCardStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPunchCardStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the preferred README for a repository.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadme: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadme"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getReadme"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the README from a repository directory.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadmeInDirectory: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#hypermedia).
+     */
+    getRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.
+     */
+    getReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a published release with the specified tag.
+     */
+    getReleaseByTag: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseByTag"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getStatusChecksProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the teams who have push access to this branch. The list includes child teams.
+     */
+    getTeamsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the people who have push access to this branch.
+     */
+    getUsersWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in a repository. To get only the webhook `config` properties, see "[Get a webhook configuration for a repository](/rest/reference/repos#get-a-webhook-configuration-for-a-repository)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the webhook configuration for a repository. To get more information about the webhook, including the `active` state and `events`, use "[Get a repository webhook](/rest/reference/orgs#get-a-repository-webhook)."
+     *
+     * Access tokens must have the `read:repo_hook` or `repo` scope, and GitHub Apps must have the `repository_hooks:read` permission.
+     */
+    getWebhookConfigForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhookConfigForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getWebhookConfigForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listBranches: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranches"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listBranches"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Returns all branches where the given commit SHA is the HEAD, or latest commit for the branch.
+     */
+    listBranchesForHeadCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use the `:commit_sha` to specify the commit that will have its comments listed.
+     */
+    listCommentsForCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Commit Comments use [these custom media types](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types). You can read more about the use of media types in the API [here](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/).
+     *
+     * Comments are ordered by ascending ID.
+     */
+    listCommitCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.
+     *
+     * This resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.
+     */
+    listCommitStatusesForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
+     *
+     * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
+     */
+    listContributors: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listContributors"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listContributors"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listDeployKeys: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view deployment statuses for a deployment:
+     */
+    listDeploymentStatuses: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Simple filtering of deployments is available via query parameters:
+     */
+    listDeployments: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories for the specified organization.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public repositories for the specified user. Note: For GitHub AE, this endpoint will list internal repositories for the specified user.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.
+     */
+    listInvitations: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user, this endpoint will list all currently open repository invitations for that user.
+     */
+    listInvitationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.
+     */
+    listLanguages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listLanguages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listLanguages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPagesBuilds: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPagesBuilds"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPagesBuilds"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all public repositories in the order that they were created.
+     *
+     * Note:
+     * - For GitHub Enterprise Server, this endpoint will only list repositories available to all users on the enterprise.
+     * - Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of repositories.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, additionally returns open pull requests associated with the commit. The results may include open and closed pull requests. Additional preview headers may be required to see certain details for associated pull requests, such as whether a pull request is in a draft state. For more information about previews that might affect this endpoint, see the [List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests) endpoint.
+     */
+    listPullRequestsAssociatedWithCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReleaseAssets: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleaseAssets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-repository-tags).
+     *
+     * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+     */
+    listReleases: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleases"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listReleases"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTags: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTags"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTags"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTeams: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTeams"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTeams"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@3.0/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of an app to push to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a team to push to this branch. You can also remove push access for child teams.
+     *
+     * | Type    | Description                                                                                                                                         |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a user to push to this branch.
+     *
+     * | Type    | Description                                                                                                                                   |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames of the people who should no longer have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    replaceAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["replaceAllTopics"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["replaceAllTopics"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.
+     *
+     * Build requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.
+     */
+    requestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["requestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["requestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    setAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of apps that have push access to this branch. This removes all apps that previously had push access and grants push access to the new list of apps. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    setStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. Team restrictions include child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.
+     *
+     * **Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`
+     */
+    testPushWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["testPushWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["testPushWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * A transfer request will need to be accepted by the new owner when transferring a personal repository to another user. The response will contain the original `owner`, and the transfer will continue asynchronously. For more details on the requirements to transfer personal and organization-owned repositories, see [about repository transfers](https://help.github.com/articles/about-repository-transfers/).
+     */
+    transfer: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["transfer"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["transfer"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: To edit a repository's topics, use the [Replace all repository topics](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#replace-all-repository-topics) endpoint.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Protecting a branch requires admin or owner permissions to the repository.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     *
+     * **Note**: The list of users, apps, and teams in total is limited to 100 items.
+     */
+    updateBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates information for a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages).
+     */
+    updateInformationAboutPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     */
+    updatePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release.
+     */
+    updateRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release asset.
+     */
+    updateReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    updateStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in a repository. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for a repository](/rest/reference/repos#update-a-webhook-configuration-for-a-repository)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the webhook configuration for a repository. To update more information about the webhook, including the `active` state and `events`, use "[Update a repository webhook](/rest/reference/orgs#update-a-repository-webhook)."
+     *
+     * Access tokens must have the `write:repo_hook` or `repo` scope, and GitHub Apps must have the `repository_hooks:write` permission.
+     */
+    updateWebhookConfigForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhookConfigForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateWebhookConfigForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint makes use of [a Hypermedia relation](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#hypermedia) to determine which URL to access. The endpoint you call to upload release assets is specific to your release. Use the `upload_url` returned in
+     * the response of the [Create a release endpoint](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#create-a-release) to upload a release asset.
+     *
+     * You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.
+     *
+     * Most libraries will set the required `Content-Length` header automatically. Use the required `Content-Type` header to provide the media type of the asset. For a list of media types, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). For example:
+     *
+     * `application/zip`
+     *
+     * GitHub Enterprise Server expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body. Everything else about the endpoint is the same as the rest of the API. For example,
+     * you'll still need to pass your authentication to be able to upload an asset.
+     *
+     * When an upstream failure occurs, you will receive a `502 Bad Gateway` status. This may leave an empty asset with a state of `starter`. It can be safely deleted.
+     *
+     * **Notes:**
+     * *   GitHub Enterprise Server renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "[List assets for a release](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-assets-for-a-release)"
+     * endpoint lists the renamed filenames. For more information and help, contact [GitHub Enterprise Server Support](https://support.github.com/contact).
+     * *   If you upload an asset with the same filename as another uploaded asset, you'll receive an error and must delete the old file before you can re-upload the new asset.
+     */
+    uploadReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  search: {
+    /**
+     * Searches for query terms inside of a file. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for code, you can get text match metadata for the file **content** and file **path** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery) repository, your query would look something like this:
+     *
+     * `q=addClass+in:file+language:js+repo:jquery/jquery`
+     *
+     * This query searches for the keyword `addClass` within a file's contents. The query limits the search to files where the language is JavaScript in the `jquery/jquery` repository.
+     *
+     * #### Considerations for code search
+     *
+     * Due to the complexity of searching code, there are a few restrictions on how searches are performed:
+     *
+     * *   Only the _default branch_ is considered. In most cases, this will be the `master` branch.
+     * *   Only files smaller than 384 KB are searchable.
+     * *   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing
+     * language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.
+     */
+    code: {
+      (
+        params?: RestEndpointMethodTypes["search"]["code"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["code"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find commits via various criteria on the default branch (usually `master`). This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for commits, you can get text match metadata for the **message** field when you provide the `text-match` media type. For more details about how to receive highlighted search results, see [Text match
+     * metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:
+     *
+     * `q=repo:octocat/Spoon-Knife+css`
+     */
+    commits: {
+      (
+        params?: RestEndpointMethodTypes["search"]["commits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["commits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find issues by state and keyword. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields when you pass the `text-match` media type. For more details about how to receive highlighted
+     * search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.
+     *
+     * `q=windows+label:bug+language:python+state:open&sort=created&order=asc`
+     *
+     * This query searches for the keyword `windows`, within any open issue that is labeled as `bug`. The search runs across repositories whose primary language is Python. The results are sorted by creation date in ascending order, which means the oldest issues appear first in the search results.
+     *
+     * **Note:** For [user-to-server](https://docs.github.com/developers/apps/identifying-and-authorizing-users-for-github-apps#user-to-server-requests) GitHub App requests, you can't retrieve a combination of issues and pull requests in a single query. Requests that don't include the `is:issue` or `is:pull-request` qualifier will receive an HTTP `422 Unprocessable Entity` response. To get results for both issues and pull requests, you must send separate queries for issues and pull requests. For more information about the `is` qualifier, see "[Searching only issues or pull requests](https://docs.github.com/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-only-issues-or-pull-requests)."
+     */
+    issuesAndPullRequests: {
+      (
+        params?: RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find labels in a repository with names or descriptions that match search keywords. Returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for labels, you can get text match metadata for the label **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find labels in the `linguist` repository that match `bug`, `defect`, or `enhancement`. Your query might look like this:
+     *
+     * `q=bug+defect+enhancement&repository_id=64778136`
+     *
+     * The labels that best match the query appear first in the search results.
+     */
+    labels: {
+      (
+        params?: RestEndpointMethodTypes["search"]["labels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["labels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find repositories via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for repositories, you can get text match metadata for the **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for popular Tetris repositories written in assembly code, your query might look like this:
+     *
+     * `q=tetris+language:assembly&sort=stars&order=desc`
+     *
+     * This query searches for repositories with the word `tetris` in the name, the description, or the README. The results are limited to repositories where the primary language is assembly. The results are sorted by stars in descending order, so that the most popular repositories appear first in the search results.
+     *
+     * When you include the `mercy` preview header, you can also search for multiple topics by adding more `topic:` instances. For example, your query might look like this:
+     *
+     * `q=topic:ruby+topic:rails`
+     */
+    repos: {
+      (
+        params?: RestEndpointMethodTypes["search"]["repos"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["repos"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find topics via various criteria. Results are sorted by best match. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination). See "[Searching topics](https://help.github.com/articles/searching-topics/)" for a detailed list of qualifiers.
+     *
+     * When searching for topics, you can get text match metadata for the topic's **short\_description**, **description**, **name**, or **display\_name** field when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for topics related to Ruby that are featured on https://github.com/topics. Your query might look like this:
+     *
+     * `q=ruby+is:featured`
+     *
+     * This query searches for topics with the keyword `ruby` and limits the results to find only topics that are featured. The topics that are the best match for the query appear first in the search results.
+     */
+    topics: {
+      (
+        params?: RestEndpointMethodTypes["search"]["topics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["topics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find users via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields when you pass the `text-match` media type. For more details about highlighting search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata). For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you're looking for a list of popular users, you might try this query:
+     *
+     * `q=tom+repos:%3E42+followers:%3E1000`
+     *
+     * This query searches for users with the name `tom`. The results are restricted to users with more than 42 repositories and over 1,000 followers.
+     */
+    users: {
+      (
+        params?: RestEndpointMethodTypes["search"]["users"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["users"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  teams: {
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adds an organization member to a team. An authenticated organization owner or team maintainer can add organization members to a team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * An organization owner can add someone who is not part of the team's organization to a team. When an organization owner adds someone to a team who is not an organization member, this endpoint will send an invitation to the person via email. This newly-created membership will be in the "pending" state until the person accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team.
+     *
+     * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    addOrUpdateMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    addOrUpdateProjectPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     *
+     * For more information about the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     */
+    addOrUpdateRepoPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    checkPermissionsForProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `admin`, `push`, `maintain`, `triage`, or `pull` permission for a repository. Repositories inherited through a parent team will also be checked.
+     *
+     * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `application/vnd.github.v3.repository+json` accept header.
+     *
+     * If a team doesn't have permission for the repository, you will receive a `404 Not Found` response status.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    checkPermissionsForRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams. Organization owners can limit team creation to organization owners. For more information, see "[Setting team creation permissions](https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization)."
+     *
+     * When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of `maintainers`. For more information, see "[About teams](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    createDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    createDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    deleteDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    deleteDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To delete a team, the authenticated user must be an organization owner or team maintainer.
+     *
+     * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}`.
+     */
+    deleteInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["deleteInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a team using the team's `slug`. GitHub Enterprise Server generates the `slug` from the team `name`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}`.
+     */
+    getByName: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getByName"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["getByName"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    getDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    getDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To get a user's membership with a team, the team must be visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     *
+     * **Note:**
+     * The response contains the `state` of the membership and the member's `role`.
+     *
+     * The `role` for organization owners is set to `maintainer`. For more information about `maintainer` roles, see see [Create a team](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#create-a-team).
+     */
+    getMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all teams in an organization that are visible to the authenticated user.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the child teams of the team specified by `{team_slug}`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/teams`.
+     */
+    listChildInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listChildInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listChildInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    listDiscussionCommentsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    listDiscussionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/).
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To list members in a team, the team must be visible to the authenticated user.
+     */
+    listMembersInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listMembersInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listMembersInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organization projects for a team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects`.
+     */
+    listProjectsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a team's repositories visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos`.
+     */
+    listReposInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listReposInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listReposInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    removeMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. This endpoint removes the project from the team, but does not delete the project.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    removeProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. This does not delete the repository, it just removes it from the team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    removeRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    updateDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    updateDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}`.
+     */
+    updateInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["updateInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  users: {
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    addEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPersonIsFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a GPG key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    deleteEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GPG key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deletePublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    follow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["follow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["follow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is authenticated through basic authentication or OAuth with the `user` scope, then the response lists public and private profile information.
+     *
+     * If the authenticated user is authenticated through OAuth without the `user` scope, then the response lists only public profile information.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides publicly available information about someone with a GitHub account.
+     *
+     * GitHub Apps with the `Plan` user permission can use this endpoint to retrieve information about a user's GitHub Enterprise Server plan. The GitHub App must be authenticated as a user. See "[Identifying and authorizing users for GitHub Apps](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)" for details about authentication. For an example response, see 'Response with GitHub Enterprise Server plan information' below"
+     *
+     * The `email` key in the following response is the publicly visible email address from your GitHub Enterprise Server [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub Enterprise Server. For more information, see [Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#authentication).
+     *
+     * The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "[Emails API](https://docs.github.com/enterprise-server@3.0/rest/reference/users#emails)".
+     */
+    getByUsername: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getByUsername"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["getByUsername"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides hovercard information when authenticated through basic auth or OAuth with the `repo` scope. You can find out more about someone in relation to their pull requests, issues, repositories, and organizations.
+     *
+     * The `subject_type` and `subject_id` parameters provide context for the person's hovercard, which returns more information than without the parameters. For example, if you wanted to find out more about `octocat` who owns the `Spoon-Knife` repository via cURL, it would look like this:
+     *
+     * ```shell
+     *  curl -u username:token
+     *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
+     * ```
+     */
+    getContextForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getContextForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getContextForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all users, in the order that they signed up on GitHub Enterprise Server. This list includes personal user accounts and organization accounts.
+     *
+     * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of users.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["users"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.
+     */
+    listEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the authenticated user follows.
+     */
+    listFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the authenticated user.
+     */
+    listFollowersForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the specified user.
+     */
+    listFollowersForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the specified user follows.
+     */
+    listFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listGpgKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the GPG keys for a user. This information is accessible by anyone.
+     */
+    listGpgKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists your publicly visible email address, which you can set with the [Set primary email visibility for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/users#set-primary-email-visibility-for-the-authenticated-user) endpoint. This endpoint is accessible with the `user:email` scope.
+     */
+    listPublicEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the _verified_ public SSH keys for a user. This is accessible by anyone.
+     */
+    listPublicKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listPublicSshKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    unfollow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["unfollow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["unfollow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.
+     */
+    updateAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["updateAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["updateAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+};

--- a/src/generated/ghe-30-parameters-and-response-types.ts
+++ b/src/generated/ghe-30-parameters-and-response-types.ts
@@ -1,0 +1,4820 @@
+import { Endpoints, RequestParameters } from "@octokit/types";
+
+export type RestEndpointMethodTypes = {
+  actions: {
+    addSelectedRepoToOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["response"];
+    };
+    cancelWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel"]["response"];
+    };
+    createOrUpdateOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}"]["response"];
+    };
+    createOrUpdateRepoSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["response"];
+    };
+    createRegistrationTokenForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/actions/runners/registration-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/actions/runners/registration-token"]["response"];
+    };
+    createRegistrationTokenForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runners/registration-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runners/registration-token"]["response"];
+    };
+    createRemoveTokenForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/actions/runners/remove-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/actions/runners/remove-token"]["response"];
+    };
+    createRemoveTokenForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runners/remove-token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runners/remove-token"]["response"];
+    };
+    createWorkflowDispatch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"]["response"];
+    };
+    deleteArtifact: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["response"];
+    };
+    deleteOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}"]["response"];
+    };
+    deleteRepoSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["response"];
+    };
+    deleteSelfHostedRunnerFromOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/runners/{runner_id}"]["response"];
+    };
+    deleteSelfHostedRunnerFromRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}"]["response"];
+    };
+    deleteWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"]["response"];
+    };
+    deleteWorkflowRunLogs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["response"];
+    };
+    disableSelectedRepositoryGithubActionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}"]["response"];
+    };
+    disableWorkflow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable"]["response"];
+    };
+    downloadArtifact: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"]["response"];
+    };
+    downloadJobLogsForWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"]["response"];
+    };
+    downloadWorkflowRunLogs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs"]["response"];
+    };
+    enableSelectedRepositoryGithubActionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/permissions/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/permissions/repositories/{repository_id}"]["response"];
+    };
+    enableWorkflow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable"]["response"];
+    };
+    getAllowedActionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/permissions/selected-actions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/permissions/selected-actions"]["response"];
+    };
+    getAllowedActionsRepository: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/permissions/selected-actions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/permissions/selected-actions"]["response"];
+    };
+    getArtifact: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["response"];
+    };
+    getGithubActionsPermissionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/permissions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/permissions"]["response"];
+    };
+    getGithubActionsPermissionsRepository: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/permissions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/permissions"]["response"];
+    };
+    getJobForWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"]["response"];
+    };
+    getOrgPublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets/public-key"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets/public-key"]["response"];
+    };
+    getOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}"]["response"];
+    };
+    getRepoPublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/secrets/public-key"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/secrets/public-key"]["response"];
+    };
+    getRepoSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"]["response"];
+    };
+    getSelfHostedRunnerForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/runners/{runner_id}"]["response"];
+    };
+    getSelfHostedRunnerForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runners/{runner_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runners/{runner_id}"]["response"];
+    };
+    getWorkflow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}"]["response"];
+    };
+    getWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}"]["response"];
+    };
+    listArtifactsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/artifacts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts"]["response"];
+    };
+    listJobsForWorkflowRun: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"]["response"];
+    };
+    listOrgSecrets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets"]["response"];
+    };
+    listRepoSecrets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/secrets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/secrets"]["response"];
+    };
+    listRepoWorkflows: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/workflows"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/workflows"]["response"];
+    };
+    listRunnerApplicationsForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/runners/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/runners/downloads"]["response"];
+    };
+    listRunnerApplicationsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runners/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runners/downloads"]["response"];
+    };
+    listSelectedReposForOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/secrets/{secret_name}/repositories"]["response"];
+    };
+    listSelectedRepositoriesEnabledGithubActionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/permissions/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/permissions/repositories"]["response"];
+    };
+    listSelfHostedRunnersForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/actions/runners"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/actions/runners"]["response"];
+    };
+    listSelfHostedRunnersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runners"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runners"]["response"];
+    };
+    listWorkflowRunArtifacts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"]["response"];
+    };
+    listWorkflowRuns: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs"]["response"];
+    };
+    listWorkflowRunsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/actions/runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/runs"]["response"];
+    };
+    reRunWorkflow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"]["response"];
+    };
+    removeSelectedRepoFromOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"]["response"];
+    };
+    setAllowedActionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/permissions/selected-actions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/permissions/selected-actions"]["response"];
+    };
+    setAllowedActionsRepository: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/actions/permissions/selected-actions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/permissions/selected-actions"]["response"];
+    };
+    setGithubActionsPermissionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/permissions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/permissions"]["response"];
+    };
+    setGithubActionsPermissionsRepository: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/actions/permissions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/permissions"]["response"];
+    };
+    setSelectedReposForOrgSecret: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"]["response"];
+    };
+    setSelectedRepositoriesEnabledGithubActionsOrganization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/actions/permissions/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/actions/permissions/repositories"]["response"];
+    };
+  };
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred/{owner}/{repo}"]["response"];
+    };
+    deleteRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    deleteThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    getFeeds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /feeds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /feeds"]["response"];
+    };
+    getRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    getThread: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}"]["response"];
+    };
+    getThreadSubscriptionForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    listEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events"]["response"];
+    };
+    listNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /notifications"]["response"];
+    };
+    listOrgEventsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/orgs/{org}"]["response"];
+    };
+    listPublicEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /events"]["response"];
+    };
+    listPublicEventsForRepoNetwork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /networks/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /networks/{owner}/{repo}/events"]["response"];
+    };
+    listPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/events/public"]["response"];
+    };
+    listPublicOrgEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/events"]["response"];
+    };
+    listReceivedEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events"]["response"];
+    };
+    listReceivedPublicEventsForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/received_events/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/received_events/public"]["response"];
+    };
+    listRepoEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/events"]["response"];
+    };
+    listRepoNotificationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    listReposStarredByAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/starred"]["response"];
+    };
+    listReposStarredByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/starred"]["response"];
+    };
+    listReposWatchedByUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/subscriptions"]["response"];
+    };
+    listStargazersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stargazers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stargazers"]["response"];
+    };
+    listWatchedReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/subscriptions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/subscriptions"]["response"];
+    };
+    listWatchersForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/subscribers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/subscribers"]["response"];
+    };
+    markNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications"]["response"];
+    };
+    markRepoNotificationsAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/notifications"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/notifications"]["response"];
+    };
+    markThreadAsRead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /notifications/threads/{thread_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /notifications/threads/{thread_id}"]["response"];
+    };
+    setRepoSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/subscription"]["response"];
+    };
+    setThreadSubscription: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /notifications/threads/{thread_id}/subscription"]["response"];
+    };
+    starRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/starred/{owner}/{repo}"]["response"];
+    };
+    unstarRepoForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/starred/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/starred/{owner}/{repo}"]["response"];
+    };
+  };
+  apps: {
+    addRepoToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    checkToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /applications/{client_id}/token"]["response"];
+    };
+    createContentAttachment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createContentAttachmentForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments"]["response"];
+    };
+    createFromManifest: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app-manifests/{code}/conversions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app-manifests/{code}/conversions"]["response"];
+    };
+    createInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /app/installations/{installation_id}/access_tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /app/installations/{installation_id}/access_tokens"]["response"];
+    };
+    deleteAuthorization: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/grant"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/grant"]["response"];
+    };
+    deleteInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /app/installations/{installation_id}"]["response"];
+    };
+    deleteToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /applications/{client_id}/token"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app"]["response"];
+    };
+    getBySlug: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /apps/{app_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /apps/{app_slug}"]["response"];
+    };
+    getInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations/{installation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations/{installation_id}"]["response"];
+    };
+    getOrgInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installation"]["response"];
+    };
+    getRepoInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/installation"]["response"];
+    };
+    getUserInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/installation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/installation"]["response"];
+    };
+    getWebhookConfigForApp: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/hook/config"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/hook/config"]["response"];
+    };
+    listInstallationReposForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations/{installation_id}/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations/{installation_id}/repositories"]["response"];
+    };
+    listInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /app/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /app/installations"]["response"];
+    };
+    listInstallationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/installations"]["response"];
+    };
+    listReposAccessibleToInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /installation/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /installation/repositories"]["response"];
+    };
+    removeRepoFromInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/installations/{installation_id}/repositories/{repository_id}"]["response"];
+    };
+    resetToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /applications/{client_id}/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /applications/{client_id}/token"]["response"];
+    };
+    revokeInstallationAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /installation/token"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /installation/token"]["response"];
+    };
+    scopeToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /applications/{client_id}/token/scoped"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /applications/{client_id}/token/scoped"]["response"];
+    };
+    suspendInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /app/installations/{installation_id}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /app/installations/{installation_id}/suspended"]["response"];
+    };
+    unsuspendInstallation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /app/installations/{installation_id}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /app/installations/{installation_id}/suspended"]["response"];
+    };
+    updateWebhookConfigForApp: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /app/hook/config"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /app/hook/config"]["response"];
+    };
+  };
+  checks: {
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-runs"]["response"];
+    };
+    createSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+    getSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"]["response"];
+    };
+    listAnnotations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"]["response"];
+    };
+    listForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["response"];
+    };
+    listForSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"]["response"];
+    };
+    listSuitesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"]["response"];
+    };
+    rerequestSuite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"]["response"];
+    };
+    setSuitesPreferences: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-suites/preferences"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]["response"];
+    };
+  };
+  codeScanning: {
+    getAlert: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["response"];
+    };
+    listAlertsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/code-scanning/alerts"]["response"];
+    };
+    listRecentAnalyses: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/code-scanning/analyses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/code-scanning/analyses"]["response"];
+    };
+    updateAlert: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"]["response"];
+    };
+    uploadSarif: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/code-scanning/sarifs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/code-scanning/sarifs"]["response"];
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct"]["response"];
+    };
+    getConductCode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /codes_of_conduct/{key}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /codes_of_conduct/{key}"]["response"];
+    };
+  };
+  emojis: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /emojis"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /emojis"]["response"];
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/settings/authorized-keys"]["response"];
+    };
+    createEnterpriseServerLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/start"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/start"]["response"];
+    };
+    createGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks"]["response"];
+    };
+    createImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users/{username}/authorizations"]["response"];
+    };
+    createOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/organizations"]["response"];
+    };
+    createPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments"]["response"];
+    };
+    createPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-hooks"]["response"];
+    };
+    createUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/users"]["response"];
+    };
+    deleteGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/hooks/{hook_id}"]["response"];
+    };
+    deleteImpersonationOAuthToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}/authorizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}/authorizations"]["response"];
+    };
+    deletePersonalAccessToken: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/tokens/{token_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/tokens/{token_id}"]["response"];
+    };
+    deletePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    deletePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    deletePublicKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/keys/{key_ids}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/keys/{key_ids}"]["response"];
+    };
+    deleteUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /admin/users/{username}"]["response"];
+    };
+    demoteSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/site_admin"]["response"];
+    };
+    disableSelectedOrganizationGithubActionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"]["response"];
+    };
+    enableOrDisableMaintenanceMode: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/maintenance"]["response"];
+    };
+    enableSelectedOrganizationGithubActionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"]["response"];
+    };
+    getAllAuthorizedSshKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings/authorized-keys"]["response"];
+    };
+    getAllStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/gists"]["response"];
+    };
+    getAllowedActionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprises/{enterprise}/actions/permissions/selected-actions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprises/{enterprise}/actions/permissions/selected-actions"]["response"];
+    };
+    getAnnouncement: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/announcement"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/announcement"]["response"];
+    };
+    getCommentStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/comments"]["response"];
+    };
+    getConfigurationStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/configcheck"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/configcheck"]["response"];
+    };
+    getDownloadStatusForPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest"]["response"];
+    };
+    getGithubActionsPermissionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprises/{enterprise}/actions/permissions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprises/{enterprise}/actions/permissions"]["response"];
+    };
+    getGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks/{hook_id}"]["response"];
+    };
+    getHooksStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/hooks"]["response"];
+    };
+    getIssueStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/issues"]["response"];
+    };
+    getLicenseInformation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/settings/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/settings/license"]["response"];
+    };
+    getMaintenanceStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/maintenance"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/maintenance"]["response"];
+    };
+    getMilestoneStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/milestones"]["response"];
+    };
+    getOrgStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/orgs"]["response"];
+    };
+    getPagesStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pages"]["response"];
+    };
+    getPreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    getPreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPreReceiveHookForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    getPullRequestStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/pulls"]["response"];
+    };
+    getRepoStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/repos"]["response"];
+    };
+    getSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /setup/api/settings"]["response"];
+    };
+    getUserStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprise/stats/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprise/stats/users"]["response"];
+    };
+    listGlobalWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/hooks"]["response"];
+    };
+    listPersonalAccessTokens: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/tokens"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/tokens"]["response"];
+    };
+    listPreReceiveEnvironments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-environments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-environments"]["response"];
+    };
+    listPreReceiveHooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/pre-receive-hooks"]["response"];
+    };
+    listPreReceiveHooksForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pre-receive-hooks"]["response"];
+    };
+    listPublicKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /admin/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /admin/keys"]["response"];
+    };
+    listSelectedOrganizationsEnabledGithubActionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /enterprises/{enterprise}/actions/permissions/organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /enterprises/{enterprise}/actions/permissions/organizations"]["response"];
+    };
+    pingGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/hooks/{hook_id}/pings"]["response"];
+    };
+    promoteUserToBeSiteAdministrator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/site_admin"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/site_admin"]["response"];
+    };
+    removeAnnouncement: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /enterprise/announcement"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /enterprise/announcement"]["response"];
+    };
+    removeAuthorizedSshKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /setup/api/settings/authorized-keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /setup/api/settings/authorized-keys"]["response"];
+    };
+    removePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    removePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    setAllowedActionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /enterprises/{enterprise}/actions/permissions/selected-actions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /enterprises/{enterprise}/actions/permissions/selected-actions"]["response"];
+    };
+    setAnnouncement: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /enterprise/announcement"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /enterprise/announcement"]["response"];
+    };
+    setGithubActionsPermissionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /enterprises/{enterprise}/actions/permissions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /enterprises/{enterprise}/actions/permissions"]["response"];
+    };
+    setSelectedOrganizationsEnabledGithubActionsEnterprise: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /enterprises/{enterprise}/actions/permissions/organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /enterprises/{enterprise}/actions/permissions/organizations"]["response"];
+    };
+    setSettings: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /setup/api/settings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /setup/api/settings"]["response"];
+    };
+    startConfigurationProcess: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/configure"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/configure"]["response"];
+    };
+    startPreReceiveEnvironmentDownload: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/pre-receive-environments/{pre_receive_environment_id}/downloads"]["response"];
+    };
+    suspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /users/{username}/suspended"]["response"];
+    };
+    syncLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/teams/{team_id}/sync"]["response"];
+    };
+    syncLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /admin/ldap/users/{username}/sync"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /admin/ldap/users/{username}/sync"]["response"];
+    };
+    unsuspendUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /users/{username}/suspended"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /users/{username}/suspended"]["response"];
+    };
+    updateGlobalWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/hooks/{hook_id}"]["response"];
+    };
+    updateLdapMappingForTeam: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/teams/{team_id}/mapping"]["response"];
+    };
+    updateLdapMappingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/ldap/users/{username}/mapping"]["response"];
+    };
+    updateOrgName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/organizations/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/organizations/{org}"]["response"];
+    };
+    updatePreReceiveEnvironment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-environments/{pre_receive_environment_id}"]["response"];
+    };
+    updatePreReceiveHook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updatePreReceiveHookEnforcementForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pre-receive-hooks/{pre_receive_hook_id}"]["response"];
+    };
+    updateUsernameForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /admin/users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /admin/users/{username}"]["response"];
+    };
+    upgradeLicense: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /setup/api/upgrade"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /setup/api/upgrade"]["response"];
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/star"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/comments"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    fork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /gists/{gist_id}/forks"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+    getRevision: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/{sha}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/commits"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gists"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gists"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/{gist_id}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/{gist_id}/forks"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/public"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/public"]["response"];
+    };
+    listStarred: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gists/starred"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gists/starred"]["response"];
+    };
+    star: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /gists/{gist_id}/star"]["response"];
+    };
+    unstar: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /gists/{gist_id}/star"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /gists/{gist_id}/star"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /gists/{gist_id}/comments/{comment_id}"]["response"];
+    };
+  };
+  git: {
+    createBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["response"];
+    };
+    createCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/commits"]["response"];
+    };
+    createRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/refs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/refs"]["response"];
+    };
+    createTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/tags"]["response"];
+    };
+    createTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/git/trees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/git/trees"]["response"];
+    };
+    deleteRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+    getBlob: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["response"];
+    };
+    getRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["response"];
+    };
+    getTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"]["response"];
+    };
+    getTree: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"]["response"];
+    };
+    listMatchingRefs: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"]["response"];
+    };
+    updateRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["response"];
+    };
+  };
+  gitignore: {
+    getAllTemplates: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates"]["response"];
+    };
+    getTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /gitignore/templates/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /gitignore/templates/{name}"]["response"];
+    };
+  };
+  issues: {
+    addAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    addLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    checkUserCanBeAssigned: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees/{assignee}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues"]["response"];
+    };
+    createComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    createLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/labels"]["response"];
+    };
+    createMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    deleteComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    deleteLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    deleteMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    getComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    getEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events/{event_id}"]["response"];
+    };
+    getLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    getMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /issues"]["response"];
+    };
+    listAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/assignees"]["response"];
+    };
+    listComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"]["response"];
+    };
+    listCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments"]["response"];
+    };
+    listEvents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/events"]["response"];
+    };
+    listEventsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/events"]["response"];
+    };
+    listEventsForTimeline: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/issues"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/issues"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
+    };
+    listLabelsForMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"]["response"];
+    };
+    listLabelsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/labels"]["response"];
+    };
+    listLabelsOnIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    listMilestones: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/milestones"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/milestones"]["response"];
+    };
+    lock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    removeAllLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    removeAssignees: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"]["response"];
+    };
+    removeLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"]["response"];
+    };
+    setLabels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"]["response"];
+    };
+    unlock: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/{issue_number}"]["response"];
+    };
+    updateComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"]["response"];
+    };
+    updateLabel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/labels/{name}"]["response"];
+    };
+    updateMilestone: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]["response"];
+    };
+  };
+  licenses: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses/{license}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses/{license}"]["response"];
+    };
+    getAllCommonlyUsed: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /licenses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /licenses"]["response"];
+    };
+    getForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/license"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/license"]["response"];
+    };
+  };
+  markdown: {
+    render: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown"]["response"];
+    };
+    renderRaw: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /markdown/raw"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /markdown/raw"]["response"];
+    };
+  };
+  meta: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /meta"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /meta"]["response"];
+    };
+    getOctocat: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /octocat"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /octocat"]["response"];
+    };
+    getZen: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /zen"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /zen"]["response"];
+    };
+    root: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /"]["response"];
+    };
+  };
+  orgs: {
+    checkMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members/{username}"]["response"];
+    };
+    checkPublicMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members/{username}"]["response"];
+    };
+    convertMemberToOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}"]["response"];
+    };
+    getMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs/{org}"]["response"];
+    };
+    getMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/memberships/{username}"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    getWebhookConfigForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks/{hook_id}/config"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks/{hook_id}/config"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /organizations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /organizations"]["response"];
+    };
+    listAppInstallations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/installations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/installations"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/orgs"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/orgs"]["response"];
+    };
+    listMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/members"]["response"];
+    };
+    listMembershipsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/memberships/orgs"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/memberships/orgs"]["response"];
+    };
+    listOutsideCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/outside_collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/outside_collaborators"]["response"];
+    };
+    listPublicMembers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/public_members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/public_members"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/hooks"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeMember: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/members/{username}"]["response"];
+    };
+    removeMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/memberships/{username}"]["response"];
+    };
+    removeOutsideCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/outside_collaborators/{username}"]["response"];
+    };
+    removePublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/public_members/{username}"]["response"];
+    };
+    setMembershipForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/memberships/{username}"]["response"];
+    };
+    setPublicMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/public_members/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/public_members/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}"]["response"];
+    };
+    updateMembershipForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/memberships/orgs/{org}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/memberships/orgs/{org}"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/hooks/{hook_id}"]["response"];
+    };
+    updateWebhookConfigForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/hooks/{hook_id}/config"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/hooks/{hook_id}/config"]["response"];
+    };
+  };
+  projects: {
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    createCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/cards"]["response"];
+    };
+    createColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/{project_id}/columns"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/projects"]["response"];
+    };
+    createForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/projects"]["response"];
+    };
+    createForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/projects"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}"]["response"];
+    };
+    deleteCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/cards/{card_id}"]["response"];
+    };
+    deleteColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/columns/{column_id}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}"]["response"];
+    };
+    getCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/cards/{card_id}"]["response"];
+    };
+    getColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}"]["response"];
+    };
+    getPermissionForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators/{username}/permission"]["response"];
+    };
+    listCards: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/columns/{column_id}/cards"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/columns/{column_id}/cards"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/collaborators"]["response"];
+    };
+    listColumns: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /projects/{project_id}/columns"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /projects/{project_id}/columns"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/projects"]["response"];
+    };
+    listForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/projects"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/projects"]["response"];
+    };
+    moveCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/cards/{card_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/cards/{card_id}/moves"]["response"];
+    };
+    moveColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /projects/columns/{column_id}/moves"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /projects/columns/{column_id}/moves"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /projects/{project_id}/collaborators/{username}"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/{project_id}"]["response"];
+    };
+    updateCard: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/cards/{card_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/cards/{card_id}"]["response"];
+    };
+    updateColumn: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /projects/columns/{column_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /projects/columns/{column_id}"]["response"];
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    createReplyForReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"]["response"];
+    };
+    createReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    createReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    deletePendingReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    deleteReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    dismissReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    getReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    getReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"];
+    };
+    listCommentsForReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"]["response"];
+    };
+    listFiles: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"]["response"];
+    };
+    listRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    listReviewComments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"]["response"];
+    };
+    listReviewCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments"]["response"];
+    };
+    listReviews: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"]["response"];
+    };
+    removeRequestedReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    requestReviewers: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"]["response"];
+    };
+    submitReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"]["response"];
+    };
+    updateBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch"]["response"];
+    };
+    updateReview: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"]["response"];
+    };
+    updateReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]["response"];
+    };
+  };
+  rateLimit: {
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /rate_limit"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /rate_limit"]["response"];
+    };
+  };
+  reactions: {
+    createForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    createForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    createForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    createForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    createForTeamDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    createForTeamDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["response"];
+    };
+    deleteForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForPullRequestComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForTeamDiscussion: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteForTeamDiscussionComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}"]["response"];
+    };
+    deleteLegacy: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /reactions/{reaction_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /reactions/{reaction_id}"]["response"];
+    };
+    listForCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions"]["response"];
+    };
+    listForIssue: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions"]["response"];
+    };
+    listForIssueComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions"]["response"];
+    };
+    listForPullRequestReviewComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions"]["response"];
+    };
+    listForTeamDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions"]["response"];
+    };
+    listForTeamDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions"]["response"];
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    addAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    addCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    addStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    addTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    addUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    checkCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    compareCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{base}...{head}"]["response"];
+    };
+    compareCommitsWithBasehead: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/compare/{basehead}"]["response"];
+    };
+    createCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    createCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    createCommitStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/statuses/{sha}"]["response"];
+    };
+    createDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/keys"]["response"];
+    };
+    createDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    createDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    createDispatchEvent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/dispatches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/dispatches"]["response"];
+    };
+    createForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/repos"]["response"];
+    };
+    createFork: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/forks"]["response"];
+    };
+    createInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/repos"]["response"];
+    };
+    createOrUpdateFileContents: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    createPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages"]["response"];
+    };
+    createRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/releases"]["response"];
+    };
+    createUsingTemplate: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{template_owner}/{template_repo}/generate"]["response"];
+    };
+    createWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    declineInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/repository_invitations/{invitation_id}"]["response"];
+    };
+    delete: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}"]["response"];
+    };
+    deleteAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    deleteAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    deleteBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    deleteCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    deleteCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    deleteDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    deleteDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    deleteFile: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    deleteInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    deletePagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/pages"]["response"];
+    };
+    deletePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    deleteRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    deleteReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    deleteWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    downloadTarballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tarball/{ref}"]["response"];
+    };
+    downloadZipballArchive: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/zipball/{ref}"]["response"];
+    };
+    get: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}"]["response"];
+    };
+    getAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"]["response"];
+    };
+    getAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    getAllStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    getAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/topics"]["response"];
+    };
+    getAppsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    getBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}"]["response"];
+    };
+    getBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    getCodeFrequencyStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/code_frequency"]["response"];
+    };
+    getCollaboratorPermissionLevel: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators/{username}/permission"]["response"];
+    };
+    getCombinedStatusForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/status"]["response"];
+    };
+    getCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}"]["response"];
+    };
+    getCommitActivityStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/commit_activity"]["response"];
+    };
+    getCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    getCommitSignatureProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures"]["response"];
+    };
+    getContent: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"];
+    };
+    getContributorsStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/contributors"]["response"];
+    };
+    getDeployKey: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys/{key_id}"]["response"];
+    };
+    getDeployment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}"]["response"];
+    };
+    getDeploymentStatus: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"]["response"];
+    };
+    getLatestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/latest"]["response"];
+    };
+    getLatestRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/latest"]["response"];
+    };
+    getPages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages"]["response"];
+    };
+    getPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds/{build_id}"]["response"];
+    };
+    getParticipationStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/participation"]["response"];
+    };
+    getPullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    getPunchCardStats: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/stats/punch_card"]["response"];
+    };
+    getReadme: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme"]["response"];
+    };
+    getReadmeInDirectory: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/readme/{dir}"]["response"];
+    };
+    getRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    getReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    getReleaseByTag: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/tags/{tag}"]["response"];
+    };
+    getStatusChecksProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    getTeamsWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    getUsersWithAccessToProtectedBranch: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    getWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    getWebhookConfigForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}/config"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks/{hook_id}/config"]["response"];
+    };
+    listBranches: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/branches"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/branches"]["response"];
+    };
+    listBranchesForHeadCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head"]["response"];
+    };
+    listCollaborators: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/collaborators"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/collaborators"]["response"];
+    };
+    listCommentsForCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"]["response"];
+    };
+    listCommitCommentsForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/comments"]["response"];
+    };
+    listCommitStatusesForRef: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/statuses"]["response"];
+    };
+    listCommits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits"]["response"];
+    };
+    listContributors: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/contributors"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/contributors"]["response"];
+    };
+    listDeployKeys: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/keys"]["response"];
+    };
+    listDeploymentStatuses: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"]["response"];
+    };
+    listDeployments: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/deployments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/deployments"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repos"]["response"];
+    };
+    listForOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/repos"]["response"];
+    };
+    listForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/repos"]["response"];
+    };
+    listForks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/forks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/forks"]["response"];
+    };
+    listInvitations: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/invitations"]["response"];
+    };
+    listInvitationsForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/repository_invitations"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/repository_invitations"]["response"];
+    };
+    listLanguages: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/languages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/languages"]["response"];
+    };
+    listPagesBuilds: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    listPublic: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repositories"]["response"];
+    };
+    listPullRequestsAssociatedWithCommit: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls"]["response"];
+    };
+    listReleaseAssets: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases/{release_id}/assets"]["response"];
+    };
+    listReleases: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/releases"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/releases"]["response"];
+    };
+    listTags: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/tags"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/tags"]["response"];
+    };
+    listTeams: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/teams"]["response"];
+    };
+    listWebhooks: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /repos/{owner}/{repo}/hooks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /repos/{owner}/{repo}/hooks"]["response"];
+    };
+    merge: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/merges"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/merges"]["response"];
+    };
+    pingWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"]["response"];
+    };
+    removeAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    removeCollaborator: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/collaborators/{username}"]["response"];
+    };
+    removeStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    removeStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    removeTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    removeUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    replaceAllTopics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/topics"]["response"];
+    };
+    requestPagesBuild: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/pages/builds"]["response"];
+    };
+    setAdminBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"]["response"];
+    };
+    setAppAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"]["response"];
+    };
+    setStatusCheckContexts: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"]["response"];
+    };
+    setTeamAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"]["response"];
+    };
+    setUserAccessRestrictions: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"]["response"];
+    };
+    testPushWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"]["response"];
+    };
+    transfer: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /repos/{owner}/{repo}/transfer"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /repos/{owner}/{repo}/transfer"]["response"];
+    };
+    update: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}"]["response"];
+    };
+    updateBranchProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/branches/{branch}/protection"]["response"];
+    };
+    updateCommitComment: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/comments/{comment_id}"]["response"];
+    };
+    updateInformationAboutPagesSite: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /repos/{owner}/{repo}/pages"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /repos/{owner}/{repo}/pages"]["response"];
+    };
+    updateInvitation: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"]["response"];
+    };
+    updatePullRequestReviewProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"]["response"];
+    };
+    updateRelease: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/{release_id}"]["response"];
+    };
+    updateReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"]["response"];
+    };
+    updateStatusCheckProtection: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"]["response"];
+    };
+    updateWebhook: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"]["response"];
+    };
+    updateWebhookConfigForRepo: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config"]["response"];
+    };
+    uploadReleaseAsset: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST {origin}/repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}"]["response"];
+    };
+  };
+  search: {
+    code: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/code"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/code"]["response"];
+    };
+    commits: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/commits"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/commits"]["response"];
+    };
+    issuesAndPullRequests: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/issues"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/issues"]["response"];
+    };
+    labels: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/labels"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/labels"]["response"];
+    };
+    repos: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/repositories"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/repositories"]["response"];
+    };
+    topics: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/topics"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/topics"]["response"];
+    };
+    users: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /search/users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /search/users"]["response"];
+    };
+  };
+  teams: {
+    addOrUpdateMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    addOrUpdateProjectPermissionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    addOrUpdateRepoPermissionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    checkPermissionsForProjectInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    checkPermissionsForRepoInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    create: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams"]["response"];
+    };
+    createDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["response"];
+    };
+    createDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /orgs/{org}/teams/{team_slug}/discussions"]["response"];
+    };
+    deleteDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    deleteDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    deleteInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getByName: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+    getDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    getDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    getMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams"]["response"];
+    };
+    listChildInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/teams"]["response"];
+    };
+    listDiscussionCommentsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"]["response"];
+    };
+    listDiscussionsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/discussions"]["response"];
+    };
+    listForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/teams"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/teams"]["response"];
+    };
+    listMembersInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["response"];
+    };
+    listProjectsInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/projects"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/projects"]["response"];
+    };
+    listReposInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /orgs/{org}/teams/{team_slug}/repos"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /orgs/{org}/teams/{team_slug}/repos"]["response"];
+    };
+    removeMembershipForUserInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"]["response"];
+    };
+    removeProjectInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"]["response"];
+    };
+    removeRepoInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"]["response"];
+    };
+    updateDiscussionCommentInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"]["response"];
+    };
+    updateDiscussionInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"]["response"];
+    };
+    updateInOrg: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /orgs/{org}/teams/{team_slug}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /orgs/{org}/teams/{team_slug}"]["response"];
+    };
+  };
+  users: {
+    addEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/emails"]["response"];
+    };
+    checkFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following/{target_user}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following/{target_user}"]["response"];
+    };
+    checkPersonIsFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following/{username}"]["response"];
+    };
+    createGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/gpg_keys"]["response"];
+    };
+    createPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["POST /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["POST /user/keys"]["response"];
+    };
+    deleteEmailForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/emails"]["response"];
+    };
+    deleteGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    deletePublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/keys/{key_id}"]["response"];
+    };
+    follow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PUT /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PUT /user/following/{username}"]["response"];
+    };
+    getAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user"]["response"];
+    };
+    getByUsername: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}"]["response"];
+    };
+    getContextForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/hovercard"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/hovercard"]["response"];
+    };
+    getGpgKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys/{gpg_key_id}"]["response"];
+    };
+    getPublicSshKeyForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys/{key_id}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys/{key_id}"]["response"];
+    };
+    list: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users"]["response"];
+    };
+    listEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/emails"]["response"];
+    };
+    listFollowedByAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/following"]["response"];
+    };
+    listFollowersForAuthenticatedUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/followers"]["response"];
+    };
+    listFollowersForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/followers"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/followers"]["response"];
+    };
+    listFollowingForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/following"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/following"]["response"];
+    };
+    listGpgKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/gpg_keys"]["response"];
+    };
+    listGpgKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/gpg_keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/gpg_keys"]["response"];
+    };
+    listPublicEmailsForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/public_emails"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/public_emails"]["response"];
+    };
+    listPublicKeysForUser: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /users/{username}/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /users/{username}/keys"]["response"];
+    };
+    listPublicSshKeysForAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["GET /user/keys"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["GET /user/keys"]["response"];
+    };
+    unfollow: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["DELETE /user/following/{username}"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["DELETE /user/following/{username}"]["response"];
+    };
+    updateAuthenticated: {
+      parameters: RequestParameters &
+        Omit<
+          Endpoints["PATCH /user"]["parameters"],
+          "baseUrl" | "headers" | "mediaType"
+        >;
+      response: Endpoints["PATCH /user"]["response"];
+    };
+  };
+};

--- a/src/generated/method-types.ts
+++ b/src/generated/method-types.ts
@@ -1,0 +1,7855 @@
+import { EndpointInterface, RequestInterface } from "@octokit/types";
+import { RestEndpointMethodTypes } from "./parameters-and-response-types";
+
+export type RestEndpointMethods = {
+  actions: {
+    /**
+     * Adds a repository to an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@3.0/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    addSelectedRepoToOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["addSelectedRepoToOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["addSelectedRepoToOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Cancels a workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    cancelWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["cancelWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["cancelWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates an organization secret with an encrypted value. Encrypt your secret using
+     * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
+     * token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to
+     * use this endpoint.
+     *
+     * #### Example encrypting a secret using Node.js
+     *
+     * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
+     *
+     * ```
+     * const sodium = require('tweetsodium');
+     *
+     * const key = "base64-encoded-public-key";
+     * const value = "plain-text-secret";
+     *
+     * // Convert the message and key to Uint8Array's (Buffer implements that interface)
+     * const messageBytes = Buffer.from(value);
+     * const keyBytes = Buffer.from(key, 'base64');
+     *
+     * // Encrypt using LibSodium.
+     * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+     *
+     * // Base64 the encrypted secret
+     * const encrypted = Buffer.from(encryptedBytes).toString('base64');
+     *
+     * console.log(encrypted);
+     * ```
+     *
+     *
+     * #### Example encrypting a secret using Python
+     *
+     * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
+     *
+     * ```
+     * from base64 import b64encode
+     * from nacl import encoding, public
+     *
+     * def encrypt(public_key: str, secret_value: str) -> str:
+     *   """Encrypt a Unicode string using the public key."""
+     *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+     *   sealed_box = public.SealedBox(public_key)
+     *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+     *   return b64encode(encrypted).decode("utf-8")
+     * ```
+     *
+     * #### Example encrypting a secret using C#
+     *
+     * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
+     *
+     * ```
+     * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
+     * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
+     *
+     * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+     *
+     * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+     * ```
+     *
+     * #### Example encrypting a secret using Ruby
+     *
+     * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
+     *
+     * ```ruby
+     * require "rbnacl"
+     * require "base64"
+     *
+     * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
+     * public_key = RbNaCl::PublicKey.new(key)
+     *
+     * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+     * encrypted_secret = box.encrypt("my_secret")
+     *
+     * # Print the base64 encoded secret
+     * puts Base64.strict_encode64(encrypted_secret)
+     * ```
+     */
+    createOrUpdateOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createOrUpdateOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createOrUpdateOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates a repository secret with an encrypted value. Encrypt your secret using
+     * [LibSodium](https://libsodium.gitbook.io/doc/bindings_for_other_languages). You must authenticate using an access
+     * token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use
+     * this endpoint.
+     *
+     * #### Example encrypting a secret using Node.js
+     *
+     * Encrypt your secret using the [tweetsodium](https://github.com/github/tweetsodium) library.
+     *
+     * ```
+     * const sodium = require('tweetsodium');
+     *
+     * const key = "base64-encoded-public-key";
+     * const value = "plain-text-secret";
+     *
+     * // Convert the message and key to Uint8Array's (Buffer implements that interface)
+     * const messageBytes = Buffer.from(value);
+     * const keyBytes = Buffer.from(key, 'base64');
+     *
+     * // Encrypt using LibSodium.
+     * const encryptedBytes = sodium.seal(messageBytes, keyBytes);
+     *
+     * // Base64 the encrypted secret
+     * const encrypted = Buffer.from(encryptedBytes).toString('base64');
+     *
+     * console.log(encrypted);
+     * ```
+     *
+     *
+     * #### Example encrypting a secret using Python
+     *
+     * Encrypt your secret using [pynacl](https://pynacl.readthedocs.io/en/stable/public/#nacl-public-sealedbox) with Python 3.
+     *
+     * ```
+     * from base64 import b64encode
+     * from nacl import encoding, public
+     *
+     * def encrypt(public_key: str, secret_value: str) -> str:
+     *   """Encrypt a Unicode string using the public key."""
+     *   public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+     *   sealed_box = public.SealedBox(public_key)
+     *   encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+     *   return b64encode(encrypted).decode("utf-8")
+     * ```
+     *
+     * #### Example encrypting a secret using C#
+     *
+     * Encrypt your secret using the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) package.
+     *
+     * ```
+     * var secretValue = System.Text.Encoding.UTF8.GetBytes("mySecret");
+     * var publicKey = Convert.FromBase64String("2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=");
+     *
+     * var sealedPublicKeyBox = Sodium.SealedPublicKeyBox.Create(secretValue, publicKey);
+     *
+     * Console.WriteLine(Convert.ToBase64String(sealedPublicKeyBox));
+     * ```
+     *
+     * #### Example encrypting a secret using Ruby
+     *
+     * Encrypt your secret using the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem.
+     *
+     * ```ruby
+     * require "rbnacl"
+     * require "base64"
+     *
+     * key = Base64.decode64("+ZYvJDZMHUfBkJdyq5Zm9SKqeuBQ4sj+6sfjlH4CgG0=")
+     * public_key = RbNaCl::PublicKey.new(key)
+     *
+     * box = RbNaCl::Boxes::Sealed.from_public_key(public_key)
+     * encrypted_secret = box.encrypt("my_secret")
+     *
+     * # Print the base64 encoded secret
+     * puts Base64.strict_encode64(encrypted_secret)
+     * ```
+     */
+    createOrUpdateRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createOrUpdateRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createOrUpdateRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script. The token expires after one hour.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     *
+     * #### Example using registration token
+     *
+     * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh --url https://github.com/octo-org --token TOKEN
+     * ```
+     */
+    createRegistrationTokenForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRegistrationTokenForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRegistrationTokenForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script. The token expires after one hour. You must authenticate
+     * using an access token with the `repo` scope to use this endpoint.
+     *
+     * #### Example using registration token
+     *
+     * Configure your self-hosted runner, replacing `TOKEN` with the registration token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh --url https://github.com/octo-org/octo-repo-artifacts --token TOKEN
+     * ```
+     */
+    createRegistrationTokenForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRegistrationTokenForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRegistrationTokenForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to the `config` script to remove a self-hosted runner from an organization. The token expires after one hour.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     *
+     * #### Example using remove token
+     *
+     * To remove your self-hosted runner from an organization, replace `TOKEN` with the remove token provided by this
+     * endpoint.
+     *
+     * ```
+     * ./config.sh remove --token TOKEN
+     * ```
+     */
+    createRemoveTokenForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRemoveTokenForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRemoveTokenForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a token that you can pass to remove a self-hosted runner from a repository. The token expires after one hour.
+     * You must authenticate using an access token with the `repo` scope to use this endpoint.
+     *
+     * #### Example using remove token
+     *
+     * To remove your self-hosted runner from a repository, replace TOKEN with the remove token provided by this endpoint.
+     *
+     * ```
+     * ./config.sh remove --token TOKEN
+     * ```
+     */
+    createRemoveTokenForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createRemoveTokenForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createRemoveTokenForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to manually trigger a GitHub Actions workflow run. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must configure your GitHub Actions workflow to run when the [`workflow_dispatch` webhook](/developers/webhooks-and-events/webhook-events-and-payloads#workflow_dispatch) event occurs. The `inputs` are configured in the workflow file. For more information about how to configure the `workflow_dispatch` event in the workflow file, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#workflow_dispatch)."
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)."
+     */
+    createWorkflowDispatch: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes an artifact for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    deleteArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteArtifact"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteArtifact"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a secret in an organization using the secret name. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    deleteOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a secret in a repository using the secret name. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    deleteRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Forces the removal of a self-hosted runner from an organization. You can use this endpoint to completely remove the runner when the machine you were using no longer exists.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    deleteSelfHostedRunnerFromOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Forces the removal of a self-hosted runner from a repository. You can use this endpoint to completely remove the runner when the machine you were using no longer exists.
+     *
+     * You must authenticate using an access token with the `repo`
+     * scope to use this endpoint.
+     */
+    deleteSelfHostedRunnerFromRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteSelfHostedRunnerFromRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a specific workflow run. Anyone with write access to the repository can use this endpoint. If the repository is
+     * private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:write` permission to use
+     * this endpoint.
+     */
+    deleteWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes all logs for a workflow run. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    deleteWorkflowRunLogs: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["deleteWorkflowRunLogs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["deleteWorkflowRunLogs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a repository from the list of selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    disableSelectedRepositoryGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["disableSelectedRepositoryGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["disableSelectedRepositoryGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Disables a workflow and sets the `state` of the workflow to `disabled_manually`. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    disableWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["disableWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["disableWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download an archive for a repository. This URL expires after 1 minute. Look for `Location:` in
+     * the response header to find the URL for the download. The `:archive_format` must be `zip`. Anyone with read access to
+     * the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+     * GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    downloadArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadArtifact"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadArtifact"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a plain text file of logs for a workflow job. This link expires after 1 minute. Look
+     * for `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can
+     * use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must
+     * have the `actions:read` permission to use this endpoint.
+     */
+    downloadJobLogsForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadJobLogsForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadJobLogsForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download an archive of log files for a workflow run. This link expires after 1 minute. Look for
+     * `Location:` in the response header to find the URL for the download. Anyone with read access to the repository can use
+     * this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have
+     * the `actions:read` permission to use this endpoint.
+     */
+    downloadWorkflowRunLogs: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["downloadWorkflowRunLogs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["downloadWorkflowRunLogs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a repository to the list of selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    enableSelectedRepositoryGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["enableSelectedRepositoryGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["enableSelectedRepositoryGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables a workflow and sets the `state` of the workflow to `active`. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    enableWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["enableWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["enableWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the selected actions that are allowed in an organization. To use this endpoint, the organization permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization).""
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    getAllowedActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getAllowedActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getAllowedActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the settings for selected actions that are allowed in a repository. To use this endpoint, the repository policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for a repository](#set-github-actions-permissions-for-a-repository)."
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    getAllowedActionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getAllowedActionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getAllowedActionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific artifact for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getArtifact: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getArtifact"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["actions"]["getArtifact"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the GitHub Actions permissions policy for repositories and allowed actions in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    getGithubActionsPermissionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the GitHub Actions permissions policy for a repository, including whether GitHub Actions is enabled and the actions allowed to run in the repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    getGithubActionsPermissionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getGithubActionsPermissionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific job in a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getJobForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getJobForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getJobForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    getOrgPublicKey: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getOrgPublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getOrgPublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a single organization secret without revealing its encrypted value. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    getOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets your public key, which you need to encrypt secrets. You need to encrypt a secret before you can create or update secrets. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    getRepoPublicKey: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getRepoPublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getRepoPublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a single repository secret without revealing its encrypted value. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    getRepoSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getRepoSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getRepoSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific self-hosted runner configured in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    getSelfHostedRunnerForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific self-hosted runner configured in a repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint.
+     */
+    getSelfHostedRunnerForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getSelfHostedRunnerForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific workflow. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getWorkflow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["actions"]["getWorkflow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a specific workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    getWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all artifacts for a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listArtifactsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listArtifactsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listArtifactsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists jobs for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#parameters).
+     */
+    listJobsForWorkflowRun: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all secrets available in an organization without revealing their encrypted values. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    listOrgSecrets: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listOrgSecrets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listOrgSecrets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all secrets available in a repository without revealing their encrypted values. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `secrets` repository permission to use this endpoint.
+     */
+    listRepoSecrets: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRepoSecrets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRepoSecrets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the workflows in a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listRepoWorkflows: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists binaries for the runner application that you can download and run.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    listRunnerApplicationsForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRunnerApplicationsForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRunnerApplicationsForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists binaries for the runner application that you can download and run.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint.
+     */
+    listRunnerApplicationsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listRunnerApplicationsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listRunnerApplicationsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all repositories that have been selected when the `visibility` for repository access to a secret is set to `selected`. You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    listSelectedReposForOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelectedReposForOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelectedReposForOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    listSelectedRepositoriesEnabledGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelectedRepositoriesEnabledGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelectedRepositoriesEnabledGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all self-hosted runners configured in an organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint.
+     */
+    listSelfHostedRunnersForOrg: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all self-hosted runners configured in a repository. You must authenticate using an access token with the `repo` scope to use this endpoint.
+     */
+    listSelfHostedRunnersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listSelfHostedRunnersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists artifacts for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listWorkflowRunArtifacts: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRunArtifacts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRunArtifacts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all workflow runs for a workflow. You can replace `workflow_id` with the workflow file name. For example, you could use `main.yaml`. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#parameters).
+     *
+     * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope.
+     */
+    listWorkflowRuns: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRuns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRuns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all workflow runs for a repository. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#parameters).
+     *
+     * Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
+     */
+    listWorkflowRunsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Re-runs your workflow run using its `id`. You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    reRunWorkflow: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["reRunWorkflow"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["reRunWorkflow"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a repository from an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@3.0/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    removeSelectedRepoFromOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["removeSelectedRepoFromOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["removeSelectedRepoFromOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the actions that are allowed in an organization. To use this endpoint, the organization permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * If the organization belongs to an enterprise that has `selected` actions set at the enterprise level, then you cannot override any of the enterprise's allowed actions settings.
+     *
+     * To use the `patterns_allowed` setting for private repositories, the organization must belong to an enterprise. If the organization does not belong to an enterprise, then the `patterns_allowed` setting only applies to public repositories in the organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    setAllowedActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setAllowedActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setAllowedActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the actions that are allowed in a repository. To use this endpoint, the repository permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for a repository](#set-github-actions-permissions-for-a-repository)."
+     *
+     * If the repository belongs to an organization or enterprise that has `selected` actions set at the organization or enterprise levels, then you cannot override any of the allowed actions settings.
+     *
+     * To use the `patterns_allowed` setting for private repositories, the repository must belong to an enterprise. If the repository does not belong to an enterprise, then the `patterns_allowed` setting only applies to public repositories.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    setAllowedActionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setAllowedActionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setAllowedActionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the GitHub Actions permissions policy for repositories and allowed actions in an organization.
+     *
+     * If the organization belongs to an enterprise that has set restrictive permissions at the enterprise level, such as `allowed_actions` to `selected` actions, then you cannot override them for the organization.
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    setGithubActionsPermissionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the GitHub Actions permissions policy for enabling GitHub Actions and allowed actions in the repository.
+     *
+     * If the repository belongs to an organization or enterprise that has set restrictive permissions at the organization or enterprise levels, such as `allowed_actions` to `selected` actions, then you cannot override them for the repository.
+     *
+     * You must authenticate using an access token with the `repo` scope to use this endpoint. GitHub Apps must have the `administration` repository permission to use this API.
+     */
+    setGithubActionsPermissionsRepository: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsRepository"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setGithubActionsPermissionsRepository"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces all repositories for an organization secret when the `visibility` for repository access is set to `selected`. The visibility is set when you [Create or update an organization secret](https://docs.github.com/enterprise-server@3.0/rest/reference/actions#create-or-update-an-organization-secret). You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `secrets` organization permission to use this endpoint.
+     */
+    setSelectedReposForOrgSecret: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setSelectedReposForOrgSecret"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setSelectedReposForOrgSecret"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces the list of selected repositories that are enabled for GitHub Actions in an organization. To use this endpoint, the organization permission policy for `enabled_repositories` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an organization](#set-github-actions-permissions-for-an-organization)."
+     *
+     * You must authenticate using an access token with the `admin:org` scope to use this endpoint. GitHub Apps must have the `administration` organization permission to use this API.
+     */
+    setSelectedRepositoriesEnabledGithubActionsOrganization: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setSelectedRepositoriesEnabledGithubActionsOrganization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setSelectedRepositoriesEnabledGithubActionsOrganization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["checkRepoIsStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint should only be used to stop watching a repository. To control whether or not you wish to receive notifications from a repository, [set the repository's subscription manually](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#set-a-repository-subscription).
+     */
+    deleteRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Mutes all future notifications for a conversation until you comment on the thread or get an **@mention**. If you are watching the repository of the thread, you will still receive notifications. To ignore future notifications for a repository you are watching, use the [Set a thread subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#set-a-thread-subscription) endpoint and set `ignore` to `true`.
+     */
+    deleteThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["deleteThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * GitHub Enterprise Server provides several timeline resources in [Atom](http://en.wikipedia.org/wiki/Atom_(standard)) format. The Feeds API lists all the feeds available to the authenticated user:
+     *
+     * *   **Timeline**: The GitHub Enterprise Server global public timeline
+     * *   **User**: The public timeline for any user, using [URI template](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#hypermedia)
+     * *   **Current user public**: The public timeline for the authenticated user
+     * *   **Current user**: The private timeline for the authenticated user
+     * *   **Current user actor**: The private timeline for activity created by the authenticated user
+     * *   **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
+     * *   **Security advisories**: A collection of public announcements that provide information about security-related vulnerabilities in software on GitHub Enterprise Server.
+     *
+     * **Note**: Private feeds are only returned when [authenticating via Basic Auth](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) since current feed URIs use the older, non revocable auth tokens.
+     */
+    getFeeds: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getFeeds"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getFeeds"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getThread: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThread"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["activity"]["getThread"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This checks to see if the current user is subscribed to a thread. You can also [get a repository subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#get-a-repository-subscription).
+     *
+     * Note that subscriptions are only generated if a user is participating in a conversation--for example, they've replied to the thread, were **@mentioned**, or manually subscribe to a thread.
+     */
+    getThreadSubscriptionForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["getThreadSubscriptionForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.
+     */
+    listEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user, sorted by most recently updated.
+     */
+    listNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This is the user's organization dashboard. You must be authenticated as the user to view this.
+     */
+    listOrgEventsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listOrgEventsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * We delay the public events feed by five minutes, which means the most recent event returned by the public events API actually occurred at least five minutes ago.
+     */
+    listPublicEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForRepoNetwork: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForRepoNetwork"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicOrgEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listPublicOrgEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * These are events that you've received by watching repos and following users. If you are authenticated as the given user, you will see private events. Otherwise, you'll only see public events.
+     */
+    listReceivedEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReceivedPublicEventsForUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReceivedPublicEventsForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRepoEvents: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoEvents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoEvents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all notifications for the current user.
+     */
+    listRepoNotificationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listRepoNotificationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user has starred.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `Accept` header:
+     */
+    listReposStarredByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposStarredByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories a user is watching.
+     */
+    listReposWatchedByUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listReposWatchedByUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people that have starred the repository.
+     *
+     * You can also find out _when_ stars were created by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `Accept` header:
+     */
+    listStargazersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listStargazersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories the authenticated user is watching.
+     */
+    listWatchedReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchedReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people watching the specified repository.
+     */
+    listWatchersForRepo: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["listWatchersForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications as "read" removes it from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List notifications for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#list-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Marks all notifications in a repository as "read" removes them from the [default view on GitHub Enterprise Server](https://github.com/notifications). If the number of notifications is too large to complete in one request, you will receive a `202 Accepted` status and GitHub Enterprise Server will run an asynchronous process to mark notifications as "read." To check whether any "unread" notifications remain, you can use the [List repository notifications for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#list-repository-notifications-for-the-authenticated-user) endpoint and pass the query parameter `all=false`.
+     */
+    markRepoNotificationsAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markRepoNotificationsAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    markThreadAsRead: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["markThreadAsRead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["markThreadAsRead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you would like to watch a repository, set `subscribed` to `true`. If you would like to ignore notifications made within a repository, set `ignored` to `true`. If you would like to stop watching a repository, [delete the repository's subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#delete-a-repository-subscription) completely.
+     */
+    setRepoSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setRepoSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setRepoSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you are watching a repository, you receive notifications for all threads by default. Use this endpoint to ignore future notifications for threads until you comment on the thread or get an **@mention**.
+     *
+     * You can also use this endpoint to subscribe to threads that you are currently not receiving notifications for or to subscribed to threads that you have previously ignored.
+     *
+     * Unsubscribing from a conversation in a repository that you are not watching is functionally equivalent to the [Delete a thread subscription](https://docs.github.com/enterprise-server@3.0/rest/reference/activity#delete-a-thread-subscription) endpoint.
+     */
+    setThreadSubscription: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["setThreadSubscription"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["setThreadSubscription"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    starRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["starRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstarRepoForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["activity"]["unstarRepoForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  apps: {
+    /**
+     * Add a single repository to an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@3.0/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    addRepoToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["addRepoToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use a special API method for checking OAuth token validity without exceeding the normal rate limits for failed login attempts. Authentication works differently with this particular endpoint. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) to use this endpoint, where the username is the OAuth application `client_id` and the password is its `client_secret`. Invalid tokens will return `404 NOT FOUND`.
+     */
+    checkToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["checkToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["checkToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated:** use `apps.createContentAttachmentForRepo()` (`POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments`) instead. Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` of the content reference from the [`content_reference` event](https://docs.github.com/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachment: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an attachment under a content reference URL in the body or comment of an issue or pull request. Use the `id` and `repository` `full_name` of the content reference from the [`content_reference` event](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#content_reference) to create an attachment.
+     *
+     * The app must create a content attachment within six hours of the content reference URL being posted. See "[Using content attachments](https://docs.github.com/enterprise-server@3.0/apps/using-content-attachments/)" for details about content attachments.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    createContentAttachmentForRepo: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createContentAttachmentForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use this endpoint to complete the handshake necessary when implementing the [GitHub App Manifest flow](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/creating-github-apps-from-a-manifest/). When you create a GitHub App with the manifest flow, you receive a temporary `code` used to retrieve the GitHub App's `id`, `pem` (private key), and `webhook_secret`.
+     */
+    createFromManifest: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createFromManifest"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createFromManifest"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an installation access token that enables a GitHub App to make authenticated API requests for the app's installation on an organization or individual account. Installation tokens expire one hour from the time you create them. Using an expired token produces a status code of `401 - Unauthorized`, and requires creating a new installation token. By default the installation token has access to all repositories that the installation can access. To restrict the access to specific repositories, you can provide the `repository_ids` when creating the token. When you omit `repository_ids`, the response does not contain the `repositories` key.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    createInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["createInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a grant for their OAuth application and a specific user. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. You must also provide a valid OAuth `access_token` as an input parameter and the grant for the token's owner will be deleted.
+     * Deleting an OAuth application's grant will also delete all OAuth tokens associated with the application for the user. Once deleted, the application will have no access to the user's account and will no longer be listed on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized).
+     */
+    deleteAuthorization: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteAuthorization"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteAuthorization"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uninstalls a GitHub App on a user, organization, or business account. If you prefer to temporarily suspend an app's access to your account's resources, then we recommend the "[Suspend an app installation](https://docs.github.com/enterprise-server@3.0/rest/reference/apps/#suspend-an-app-installation)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    deleteInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["deleteInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth application owners can revoke a single token for an OAuth application. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password.
+     */
+    deleteToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["deleteToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["deleteToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the "[List installations for the authenticated app](https://docs.github.com/enterprise-server@3.0/rest/reference/apps#list-installations-for-the-authenticated-app)" endpoint.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: The `:app_slug` is just the URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App (e.g., `https://github.com/settings/apps/:app_slug`).
+     *
+     * If the GitHub App you specify is public, you can access this endpoint without authenticating. If the GitHub App you specify is private, you must authenticate with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) or an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    getBySlug: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getBySlug"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["getBySlug"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find an installation's information using the installation id. The installation's account type (`target_type`) will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the organization's installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getOrgInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getOrgInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getOrgInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the repository's installation information. The installation's account type will be either an organization or a user account, depending which account the repository belongs to.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getRepoInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getRepoInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getRepoInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables an authenticated GitHub App to find the user’s installation information.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getUserInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getUserInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getUserInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the webhook configuration for a GitHub App. For more information about configuring a webhook for your app, see "[Creating a GitHub App](/developers/apps/creating-a-github-app)."
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    getWebhookConfigForApp: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["getWebhookConfigForApp"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["getWebhookConfigForApp"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access for an installation.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The access the user has to each repository is included in the hash under the `permissions` key.
+     */
+    listInstallationReposForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationReposForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     *
+     * The permissions the installation has are included under the `permissions` key.
+     */
+    listInstallations: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists installations of your GitHub App that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * You must use a [user-to-server OAuth access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#identifying-users-on-your-site), created for a user who has authorized your GitHub App, to access this endpoint.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     *
+     * You can find the permissions for the installation under the `permissions` key.
+     */
+    listInstallationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listInstallationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List repositories that an app installation can access.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    listReposAccessibleToInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["listReposAccessibleToInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Remove a single repository from an installation. The authenticated user must have admin access to the repository.
+     *
+     * You must use a personal access token (which you can create via the [command line](https://docs.github.com/enterprise-server@3.0/github/authenticating-to-github/creating-a-personal-access-token) or [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication)) to access this endpoint.
+     */
+    removeRepoFromInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["removeRepoFromInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * OAuth applications can use this API method to reset a valid OAuth token without end-user involvement. Applications must save the "token" property in the response because changes take effect immediately. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    resetToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["resetToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["resetToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Revokes the installation token you're using to authenticate as an installation and access this endpoint.
+     *
+     * Once an installation token is revoked, the token is invalidated and cannot be used. Other endpoints that require the revoked installation token must have a new installation token to work. You can create a new token using the "[Create an installation access token for an app](https://docs.github.com/enterprise-server@3.0/rest/reference/apps#create-an-installation-access-token-for-an-app)" endpoint.
+     *
+     * You must use an [installation access token](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation) to access this endpoint.
+     */
+    revokeInstallationAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["revokeInstallationAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use a non-scoped user-to-server OAuth access token to create a repository scoped and/or permission scoped user-to-server OAuth access token. You can specify which repositories the token can access and which permissions are granted to the token. You must use [Basic Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/other-authentication-methods#basic-authentication) when accessing this endpoint, using the OAuth application's `client_id` and `client_secret` as the username and password. Invalid tokens will return `404 NOT FOUND`.
+     */
+    scopeToken: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["scopeToken"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["apps"]["scopeToken"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Suspends a GitHub App on a user, organization, or business account, which blocks the app from accessing the account's resources. When a GitHub App is suspended, the app's access to the GitHub Enterprise Server API or webhook events is blocked for that account.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    suspendInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["suspendInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["suspendInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GitHub App installation suspension.
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    unsuspendInstallation: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["unsuspendInstallation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["unsuspendInstallation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the webhook configuration for a GitHub App. For more information about configuring a webhook for your app, see "[Creating a GitHub App](/developers/apps/creating-a-github-app)."
+     *
+     * You must use a [JWT](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.
+     */
+    updateWebhookConfigForApp: {
+      (
+        params?: RestEndpointMethodTypes["apps"]["updateWebhookConfigForApp"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["apps"]["updateWebhookConfigForApp"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  checks: {
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Creates a new check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to create check runs.
+     *
+     * In a check suite, GitHub limits the number of check runs with the same name to 1000. Once these check runs exceed 1000, GitHub will start to automatically delete older check runs.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * By default, check suites are automatically created when you create a [check run](https://docs.github.com/enterprise-server@3.0/rest/reference/checks#check-runs). You only need to use this endpoint for manually creating check suites when you've disabled automatic creation using "[Update repository preferences for check suites](https://docs.github.com/enterprise-server@3.0/rest/reference/checks#update-repository-preferences-for-check-suites)". Your GitHub App must have the `checks:write` permission to create check suites.
+     */
+    createSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["createSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["createSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    getSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["getSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["getSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.
+     */
+    listAnnotations: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listAnnotations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listAnnotations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
+     */
+    listForSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listForSuite"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["listForSuite"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array and a `null` value for `head_branch`.
+     *
+     * Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.
+     */
+    listSuitesForRef: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["listSuitesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["listSuitesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository. This endpoint will trigger the [`check_suite` webhook](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#check_suite) event with the action `rerequested`. When a check suite is `rerequested`, its `status` is reset to `queued` and the `conclusion` is cleared.
+     *
+     * To rerequest a check suite, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.
+     */
+    rerequestSuite: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["rerequestSuite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["rerequestSuite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Changes the default automatic flow when creating check suites. By default, a check suite is automatically created each time code is pushed to a repository. When you disable the automatic creation of check suites, you can manually [Create a check suite](https://docs.github.com/enterprise-server@3.0/rest/reference/checks#create-a-check-suite). You must have admin permissions in the repository to set preferences for check suites.
+     */
+    setSuitesPreferences: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["checks"]["setSuitesPreferences"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** The Checks API only looks for pushes in the repository where the check suite or check run were created. Pushes to a branch in a forked repository are not detected and return an empty `pull_requests` array.
+     *
+     * Updates a check run for a specific commit in a repository. Your GitHub App must have the `checks:write` permission to edit check runs.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["checks"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["checks"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codeScanning: {
+    /**
+     * Gets a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` read permission to use this endpoint.
+     *
+     * **Deprecation notice**:
+     * The instances field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The same information can now be retrieved via a GET request to the URL specified by `instances_url`.
+     */
+    getAlert: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["getAlert"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["getAlert"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all open code scanning alerts for the default branch (usually `main`
+     * or `master`). You must use an access token with the `security_events` scope to use
+     * this endpoint. GitHub Apps must have the `security_events` read permission to use
+     * this endpoint.
+     *
+     * The response includes a `most_recent_instance` object.
+     * This provides details of the most recent instance of this alert
+     * for the default branch or for the specified Git reference
+     * (if you used `ref` in the request).
+     */
+    listAlertsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["listAlertsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["listAlertsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the details of all code scanning analyses for a repository,
+     * starting with the most recent.
+     * The response is paginated and you can use the `page` and `per_page` parameters
+     * to list the analyses you're interested in.
+     * By default 30 analyses are listed per page.
+     *
+     * The `rules_count` field in the response give the number of rules
+     * that were run in the analysis.
+     * For very old analyses this data is not available,
+     * and `0` is returned in this field.
+     *
+     * You must use an access token with the `security_events` scope to use this endpoint.
+     * GitHub Apps must have the `security_events` read permission to use this endpoint.
+     *
+     * **Deprecation notice**:
+     * The `tool_name` field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The tool name can now be found inside the `tool` field.
+     */
+    listRecentAnalyses: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["listRecentAnalyses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["listRecentAnalyses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the status of a single code scanning alert. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` write permission to use this endpoint.
+     */
+    updateAlert: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["updateAlert"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["updateAlert"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Uploads SARIF data containing the results of a code scanning analysis to make the results available in a repository. You must use an access token with the `security_events` scope to use this endpoint. GitHub Apps must have the `security_events` write permission to use this endpoint.
+     *
+     * There are two places where you can upload code scanning results.
+     *  - If you upload to a pull request, for example `--ref refs/pull/42/merge` or `--ref refs/pull/42/head`, then the results appear as alerts in a pull request check. For more information, see "[Triaging code scanning alerts in pull requests](/code-security/secure-coding/triaging-code-scanning-alerts-in-pull-requests)."
+     *  - If you upload to a branch, for example `--ref refs/heads/my-branch`, then the results appear in the **Security** tab for your repository. For more information, see "[Managing code scanning alerts for your repository](/code-security/secure-coding/managing-code-scanning-alerts-for-your-repository#viewing-the-alerts-for-a-repository)."
+     *
+     * You must compress the SARIF-formatted analysis data that you want to upload, using `gzip`, and then encode it as a Base64 format string. For example:
+     *
+     * ```
+     * gzip -c analysis-data.sarif | base64 -w0
+     * ```
+     *
+     * SARIF upload supports a maximum of 1000 results per analysis run. Any results over this limit are ignored. Typically, but not necessarily, a SARIF file contains a single run of a single tool. If a code scanning tool generates too many results, you should update the analysis configuration to run only the most important rules or queries.
+     *
+     * The `202 Accepted`, response includes an `id` value.
+     * You can use this ID to check the status of the upload by using this for the `/sarifs/{sarif_id}` endpoint.
+     * For more information, see "[Get information about a SARIF upload](/rest/reference/code-scanning#get-information-about-a-sarif-upload)."
+     */
+    uploadSarif: {
+      (
+        params?: RestEndpointMethodTypes["codeScanning"]["uploadSarif"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codeScanning"]["uploadSarif"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  codesOfConduct: {
+    getAllCodesOfConduct: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getAllCodesOfConduct"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getConductCode: {
+      (
+        params?: RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["codesOfConduct"]["getConductCode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  emojis: {
+    /**
+     * Lists all the emojis available to use on GitHub Enterprise Server.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["emojis"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["emojis"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  enterpriseAdmin: {
+    addAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["addAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you boot a GitHub instance for the first time, you can use the following endpoint to upload a license:
+     *
+     * Note that you need to POST to [`/setup/api/configure`](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#start-a-configuration-process) to start the actual configuration process.
+     *
+     * When using this endpoint, your GitHub instance must have a password set. This can be accomplished two ways:
+     *
+     * 1.  If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
+     * 2.  If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
+     *
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#get-settings).
+     */
+    createEnterpriseServerLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createEnterpriseServerLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If an external authentication mechanism is used, the login name should match the login name in the external system. If you are using LDAP authentication, you should also [update the LDAP mapping](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#update-ldap-mapping-for-a-user) for the user.
+     *
+     * The login name will be normalized to only contain alphanumeric characters or single hyphens. For example, if you send `"octo_cat"` as the login, a user named `"octo-cat"` will be created.
+     *
+     * If the login name or email address is already associated with an account, the server will return a `422` response.
+     */
+    createUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["createUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteImpersonationOAuthToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteImpersonationOAuthToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a personal access token. Returns a `403 - Forbidden` status when a personal access token is in use. For example, if you access this endpoint with the same personal access token that you are trying to delete, you will receive this error.
+     */
+    deletePersonalAccessToken: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePersonalAccessToken"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If you attempt to delete an environment that cannot be deleted, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * *   _Cannot modify or delete the default environment_
+     * *   _Cannot delete environment that has hooks_
+     * *   _Cannot delete environment when download is in progress_
+     */
+    deletePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePublicKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deletePublicKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a user will delete all their repositories, gists, applications, and personal settings. [Suspending a user](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#suspend-a-user) is often a better option.
+     *
+     * You can delete any user account except your own.
+     */
+    deleteUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["deleteUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can demote any user account except your own.
+     */
+    demoteSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["demoteSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization from the list of selected organizations that are enabled for GitHub Actions in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    disableSelectedOrganizationGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["disableSelectedOrganizationGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["disableSelectedOrganizationGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The possible values for `enabled` are `true` and `false`. When it's `false`, the attribute `when` is ignored and the maintenance mode is turned off. `when` defines the time period when the maintenance was enabled.
+     *
+     * The possible values for `when` are `now` or any date parseable by [mojombo/chronic](https://github.com/mojombo/chronic).
+     */
+    enableOrDisableMaintenanceMode: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableOrDisableMaintenanceMode"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization to the list of selected organizations that are enabled for GitHub Actions in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    enableSelectedOrganizationGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["enableSelectedOrganizationGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["enableSelectedOrganizationGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllAuthorizedSshKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllAuthorizedSshKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the selected actions that are allowed in an enterprise. To use this endpoint, the enterprise permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    getAllowedActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAllowedActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAllowedActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the current message and expiration date of the global announcement banner in your enterprise.
+     */
+    getAnnouncement: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getAnnouncement"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getAnnouncement"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to check the status of the most recent configuration process:
+     *
+     * Note that you may need to wait several seconds after you start a process before you can check its status.
+     *
+     * The different statuses are:
+     *
+     * | Status        | Description                       |
+     * | ------------- | --------------------------------- |
+     * | `PENDING`     | The job has not started yet       |
+     * | `CONFIGURING` | The job is running                |
+     * | `DONE`        | The job has finished correctly    |
+     * | `FAILED`      | The job has finished unexpectedly |
+     */
+    getConfigurationStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getConfigurationStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In addition to seeing the download status at the "[Get a pre-receive environment](#get-a-pre-receive-environment)" endpoint, there is also this separate endpoint for just the download status.
+     */
+    getDownloadStatusForPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getDownloadStatusForPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the GitHub Actions permissions policy for organizations and allowed actions in an enterprise.
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    getGithubActionsPermissionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGithubActionsPermissionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGithubActionsPermissionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLicenseInformation: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getLicenseInformation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Check your installation's maintenance status:
+     */
+    getMaintenanceStatus: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getMaintenanceStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPreReceiveHookForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getPreReceiveHookForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * There are a variety of types to choose from:
+     *
+     * | Type         | Description                                                                                         |
+     * | ------------ | --------------------------------------------------------------------------------------------------- |
+     * | `issues`     | The number of open and closed issues.                                                               |
+     * | `hooks`      | The number of active and inactive hooks.                                                            |
+     * | `milestones` | The number of open and closed milestones.                                                           |
+     * | `orgs`       | The number of organizations, teams, team members, and disabled organizations.                       |
+     * | `comments`   | The number of comments on issues, pull requests, commits, and gists.                                |
+     * | `pages`      | The number of GitHub Pages sites.                                                                   |
+     * | `users`      | The number of suspended and admin users.                                                            |
+     * | `gists`      | The number of private and public gists.                                                             |
+     * | `pulls`      | The number of merged, mergeable, and unmergeable pull requests.                                     |
+     * | `repos`      | The number of organization-owned repositories, root repositories, forks, pushed commits, and wikis. |
+     * | `all`        | All of the statistics listed above.                                                                 |
+     *
+     * These statistics are cached and will be updated approximately every 10 minutes.
+     */
+    getTypeStats: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["getTypeStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["getTypeStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listGlobalWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listGlobalWebhooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists personal access tokens for all users, including admin users.
+     */
+    listPersonalAccessTokens: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPersonalAccessTokens"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveEnvironments: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveEnvironments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPreReceiveHooks: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooks"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this organization as well as any disabled hooks that can be configured at the organization level. Globally disabled pre-receive hooks that do not allow downstream configuration are not listed.
+     */
+    listPreReceiveHooksForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all pre-receive hooks that are enabled or testing for this repository as well as any disabled hooks that are allowed to be enabled at the repository level. Pre-receive hooks that are disabled at a higher level and are not configurable will not be listed.
+     */
+    listPreReceiveHooksForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPreReceiveHooksForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPublicKeys: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listPublicKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organizations that are selected to have GitHub Actions enabled in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    listSelectedOrganizationsEnabledGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["listSelectedOrganizationsEnabledGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["listSelectedOrganizationsEnabledGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@3.0/webhooks/#ping-event) to be sent to the webhook.
+     */
+    pingGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["pingGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    promoteUserToBeSiteAdministrator: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["promoteUserToBeSiteAdministrator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the global announcement banner in your enterprise.
+     */
+    removeAnnouncement: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAnnouncement"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAnnouncement"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAuthorizedSshKey: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removeAuthorizedSshKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any overrides for this hook at the org level for this org.
+     */
+    removePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes any overridden enforcement on this repository for the specified hook.
+     *
+     * Responds with effective values inherited from owner and/or global level.
+     */
+    removePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["removePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the actions that are allowed in an enterprise. To use this endpoint, the enterprise permission policy for `allowed_actions` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    setAllowedActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setAllowedActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setAllowedActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the message and expiration time for the global announcement banner in your enterprise.
+     */
+    setAnnouncement: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setAnnouncement"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setAnnouncement"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the GitHub Actions permissions policy for organizations and allowed actions in an enterprise.
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    setGithubActionsPermissionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setGithubActionsPermissionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setGithubActionsPermissionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Replaces the list of selected organizations that are enabled for GitHub Actions in an enterprise. To use this endpoint, the enterprise permission policy for `enabled_organizations` must be configured to `selected`. For more information, see "[Set GitHub Actions permissions for an enterprise](#set-github-actions-permissions-for-an-enterprise)."
+     *
+     * You must authenticate using an access token with the `admin:enterprise` scope to use this endpoint.
+     */
+    setSelectedOrganizationsEnabledGithubActionsEnterprise: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSelectedOrganizationsEnabledGithubActionsEnterprise"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSelectedOrganizationsEnabledGithubActionsEnterprise"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For a list of the available settings, see the [Get settings endpoint](https://docs.github.com/enterprise-server@3.0/rest/reference/enterprise-admin#get-settings).
+     */
+    setSettings: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["setSettings"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint allows you to start a configuration process at any time for your updated settings to take effect:
+     */
+    startConfigurationProcess: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startConfigurationProcess"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Triggers a new download of the environment tarball from the environment's `image_url`. When the download is finished, the newly downloaded tarball will overwrite the existing environment.
+     *
+     * If a download cannot be triggered, you will receive a `422 Unprocessable Entity` response.
+     *
+     * The possible error messages are:
+     *
+     * * _Cannot modify or delete the default environment_
+     * * _Can not start a new download when a download is in progress_
+     */
+    startPreReceiveEnvironmentDownload: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["startPreReceiveEnvironmentDownload"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), Active Directory LDAP-authenticated users cannot be suspended through this API. If you attempt to suspend an Active Directory LDAP-authenticated user through this API, it will return a `403` response.
+     *
+     * You can suspend any user account except your own.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    suspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["suspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that this API call does not automatically initiate an LDAP sync. Rather, if a `201` is returned, the sync job is queued successfully, and is performed when the instance is ready.
+     */
+    syncLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["syncLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If your GitHub instance uses [LDAP Sync with Active Directory LDAP servers](https://help.github.com/enterprise/admin/guides/user-management/using-ldap), this API is disabled and will return a `403` response. Active Directory LDAP-authenticated users cannot be unsuspended using the API.
+     */
+    unsuspendUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["unsuspendUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Parameters that are not provided will be overwritten with the default value or removed if no default exists.
+     */
+    updateGlobalWebhook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateGlobalWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the [distinguished name](https://www.ldap.com/ldap-dns-and-rdns) (DN) of the LDAP entry to map to a team. [LDAP synchronization](https://help.github.com/enterprise/admin/guides/user-management/using-ldap/#enabling-ldap-sync) must be enabled to map LDAP entries to a team. Use the [Create a team](https://docs.github.com/enterprise-server@3.0/rest/reference/teams/#create-a-team) endpoint to create a team with LDAP mapping.
+     *
+     * If you pass the `hellcat-preview` media type, you can also update the LDAP mapping of a child team.
+     */
+    updateLdapMappingForTeam: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForTeam"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLdapMappingForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateLdapMappingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateOrgName: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateOrgName"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You cannot modify the default environment. If you attempt to modify the default environment, you will receive a `422 Unprocessable Entity` response.
+     */
+    updatePreReceiveEnvironment: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveEnvironment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updatePreReceiveHook: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the org level, you can set `enforcement` and `allow_downstream_configuration`
+     */
+    updatePreReceiveHookEnforcementForOrg: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For pre-receive hooks which are allowed to be configured at the repo level, you can set `enforcement`
+     */
+    updatePreReceiveHookEnforcementForRepo: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updatePreReceiveHookEnforcementForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateUsernameForUser: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["updateUsernameForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This API upgrades your license and also triggers the configuration process:
+     */
+    upgradeLicense: {
+      (
+        params?: RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["enterpriseAdmin"]["upgradeLicense"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gists: {
+    checkIsStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["checkIsStarred"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gists"]["checkIsStarred"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to add a new gist with one or more files.
+     *
+     * **Note:** Don't name your files "gistfile" with a numerical suffix. This is the format of the automatic naming scheme that Gist uses internally.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["createComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["createComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["deleteComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["deleteComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: This was previously `/gists/:gist_id/fork`.
+     */
+    fork: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["fork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["fork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    get: {
+      (params?: RestEndpointMethodTypes["gists"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["gists"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getRevision: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["getRevision"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["getRevision"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the authenticated user's gists or if called anonymously, this endpoint returns all public gists:
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public gists for the specified user:
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List public gists sorted by most recently updated to least recently updated.
+     *
+     * Note: With [pagination](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination), you can fetch up to 3000 gists. For example, you can fetch 100 pages with 30 gists per page or 30 pages with 100 gists per page.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the authenticated user's starred gists:
+     */
+    listStarred: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["listStarred"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["listStarred"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    star: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["star"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["star"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    unstar: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["unstar"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["unstar"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Allows you to update or delete a gist file and rename gist files. Files from the previous version of the gist that aren't explicitly changed during an edit are unchanged.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["gists"]["updateComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["gists"]["updateComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  git: {
+    createBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reference for your repository. You are unable to create new references for empty repositories, even if the commit SHA-1 hash used exists. Empty repositories are repositories without branches.
+     */
+    createRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create an annotated tag in Git, you have to do this call to create the tag object, and then [create](https://docs.github.com/enterprise-server@3.0/rest/reference/git#create-a-reference) the `refs/tags/[tag]` reference. If you want to create a lightweight tag, you only have to [create](https://docs.github.com/enterprise-server@3.0/rest/reference/git#create-a-reference) the tag reference - this call would be unnecessary.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    createTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The tree creation API accepts nested entries. If you specify both a tree and a nested path modifying that tree, this endpoint will overwrite the contents of the tree with the new path contents, and create a new tree structure.
+     *
+     * If you use this endpoint to add, delete, or modify the file contents in a tree, you will need to commit the tree and then update a branch to point to the commit. For more information see "[Create a commit](https://docs.github.com/enterprise-server@3.0/rest/reference/git#create-a-commit)" and "[Update a reference](https://docs.github.com/enterprise-server@3.0/rest/reference/git#update-a-reference)."
+     */
+    createTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["createTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["createTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["deleteRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["deleteRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `content` in the response will always be Base64 encoded.
+     *
+     * _Note_: This API supports blobs up to 100 megabytes in size.
+     */
+    getBlob: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getBlob"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getBlob"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a Git [commit object](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Commit-Objects).
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single reference from your Git database. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't match an existing ref, a `404` is returned.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@3.0/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     */
+    getRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getTag: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTag"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTag"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a single tree using the SHA1 value for that tree.
+     *
+     * If `truncated` is `true` in the response then the number of items in the `tree` array exceeded our maximum limit. If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+     */
+    getTree: {
+      (
+        params?: RestEndpointMethodTypes["git"]["getTree"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["getTree"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns an array of references from your Git database that match the supplied name. The `:ref` in the URL must be formatted as `heads/<branch name>` for branches and `tags/<tag name>` for tags. If the `:ref` doesn't exist in the repository, but existing refs start with `:ref`, they will be returned as an array.
+     *
+     * When you use this endpoint without providing a `:ref`, it will return an array of all the references from your Git database, including notes and stashes if they exist on the server. Anything in the namespace is returned, not just `heads` and `tags`.
+     *
+     * **Note:** You need to explicitly [request a pull request](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#get-a-pull-request) to trigger a test merge commit, which checks the mergeability of pull requests. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@3.0/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * If you request matching references for a branch named `feature` but the branch `feature` doesn't exist, the response can still include other matching head refs that start with the word `feature`, such as `featureA` and `featureB`.
+     */
+    listMatchingRefs: {
+      (
+        params?: RestEndpointMethodTypes["git"]["listMatchingRefs"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["git"]["listMatchingRefs"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateRef: {
+      (
+        params?: RestEndpointMethodTypes["git"]["updateRef"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["git"]["updateRef"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  gitignore: {
+    /**
+     * List all templates available to pass as an option when [creating a repository](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#create-a-repository-for-the-authenticated-user).
+     */
+    getAllTemplates: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getAllTemplates"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API also allows fetching the source of a single template.
+     * Use the raw [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) to get the raw contents.
+     */
+    getTemplate: {
+      (
+        params?: RestEndpointMethodTypes["gitignore"]["getTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["gitignore"]["getTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  issues: {
+    /**
+     * Adds up to 10 assignees to an issue. Users already assigned to an issue are not replaced.
+     */
+    addAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addAssignees"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addAssignees"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    addLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["addLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["addLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks if a user has permission to be assigned to an issue in this repository.
+     *
+     * If the `assignee` can be assigned to issues in the repository, a `204` header with no content is returned.
+     *
+     * Otherwise a `404` status code is returned.
+     */
+    checkUserCanBeAssigned: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["checkUserCanBeAssigned"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Any user with pull access to a repository can create an issue. If [issues are disabled in the repository](https://help.github.com/articles/disabling-issues/), the API returns a `410 Gone` status.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    createComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["createLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["createMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["createMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["deleteLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["deleteMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["deleteMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The API returns a [`301 Moved Permanently` status](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-redirects-redirects) if the issue was
+     * [transferred](https://help.github.com/articles/transferring-an-issue-to-another-repository/) to another repository. If
+     * the issue was transferred to or deleted from a repository where the authenticated user lacks read access, the API
+     * returns a `404 Not Found` status. If the issue was deleted from a repository where the authenticated user has read
+     * access, the API returns a `410 Gone` status. To receive webhook events for transferred and deleted issues, subscribe
+     * to the [`issues`](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#issues) webhook.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getComment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getComment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getEvent: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getEvent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getEvent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["getMilestone"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["getMilestone"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues assigned to the authenticated user across all visible repositories including owned repositories, member
+     * repositories, and organization repositories. You can use the `filter` query parameter to fetch issues that are not
+     * necessarily assigned to you.
+     *
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the [available assignees](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) for issues in a repository.
+     */
+    listAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue Comments are ordered by ascending ID.
+     */
+    listComments: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listComments"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listComments"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * By default, Issue Comments are ordered by ascending ID.
+     */
+    listCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEvents: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEvents"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listEvents"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listEventsForTimeline: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues across owned and member repositories assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in an organization assigned to the authenticated user.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List issues in a repository.
+     *
+     * **Note**: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this
+     * reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by
+     * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
+     * request id, use the "[List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests)" endpoint.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["listForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listLabelsOnIssue: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMilestones: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["listMilestones"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["listMilestones"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can lock an issue or pull request's conversation.
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    lock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["lock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["lock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeAllLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAllLabels"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAllLabels"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes one or more assignees from an issue.
+     */
+    removeAssignees: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeAssignees"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["removeAssignees"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes the specified label from the issue, and returns the remaining labels on the issue. This endpoint returns a `404 Not Found` status if the label does not exist.
+     */
+    removeLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["removeLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["removeLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes any previous labels and sets the new labels for an issue.
+     */
+    setLabels: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["setLabels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["setLabels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access can unlock an issue's conversation.
+     */
+    unlock: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["unlock"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["unlock"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Issue owners and users with push access can edit an issue.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateComment: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateLabel: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateLabel"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["issues"]["updateLabel"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMilestone: {
+      (
+        params?: RestEndpointMethodTypes["issues"]["updateMilestone"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["issues"]["updateMilestone"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  licenses: {
+    get: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllCommonlyUsed: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["licenses"]["getAllCommonlyUsed"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This method returns the contents of the repository's license file, if one is detected.
+     *
+     * Similar to [Get repository content](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#get-repository-content), this method also supports [custom media types](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types) for retrieving the raw license content or rendered license HTML.
+     */
+    getForRepo: {
+      (
+        params?: RestEndpointMethodTypes["licenses"]["getForRepo"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["licenses"]["getForRepo"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  markdown: {
+    render: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["render"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["render"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You must send Markdown as plain text (using a `Content-Type` header of `text/plain` or `text/x-markdown`) to this endpoint, rather than using JSON format. In raw mode, [GitHub Flavored Markdown](https://github.github.com/gfm/) is not supported and Markdown will be rendered in plain format like a README.md file. Markdown content must be 400 KB or less.
+     */
+    renderRaw: {
+      (
+        params?: RestEndpointMethodTypes["markdown"]["renderRaw"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["markdown"]["renderRaw"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  meta: {
+    get: {
+      (params?: RestEndpointMethodTypes["meta"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get the octocat as ASCII art
+     */
+    getOctocat: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getOctocat"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getOctocat"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a random sentence from the Zen of GitHub
+     */
+    getZen: {
+      (
+        params?: RestEndpointMethodTypes["meta"]["getZen"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["meta"]["getZen"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get Hypermedia links to resources accessible in GitHub's REST API
+     */
+    root: {
+      (params?: RestEndpointMethodTypes["meta"]["root"]["parameters"]): Promise<
+        RestEndpointMethodTypes["meta"]["root"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  orgs: {
+    /**
+     * Check if a user is, publicly or privately, a member of the organization.
+     */
+    checkMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPublicMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["checkPublicMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When an organization member is converted to an outside collaborator, they'll only have access to the repositories that their current team membership allows. The user will no longer be a member of the organization. For more information, see "[Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)".
+     */
+    convertMemberToOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["convertMemberToOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Here's how you can create a hook that posts payloads in JSON format:
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To see many of the organization response values, you need to be an authenticated organization owner with the `admin:org` scope. When the value of `two_factor_requirement_enabled` is `true`, the organization requires all members, billing managers, and outside collaborators to enable [two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
+     *
+     * GitHub Apps with the `Organization plan` permission can use this endpoint to retrieve information about an organization's GitHub Enterprise Server plan. See "[Authenticating with GitHub Apps](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/authenticating-with-github-apps/)" for details. For an example response, see 'Response with GitHub Enterprise Server plan information' below."
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["orgs"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to get a user's membership with an organization, the authenticated user must be an organization member. The `state` parameter in the response can be used to identify the user's membership status.
+     */
+    getMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in an organization. To get only the webhook `config` properties, see "[Get a webhook configuration for an organization](/rest/reference/orgs#get-a-webhook-configuration-for-an-organization)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the webhook configuration for an organization. To get more information about the webhook, including the `active` state and `events`, use "[Get an organization webhook ](/rest/reference/orgs#get-an-organization-webhook)."
+     *
+     * Access tokens must have the `admin:org_hook` scope, and GitHub Apps must have the `organization_hooks:read` permission.
+     */
+    getWebhookConfigForOrg: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["getWebhookConfigForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["getWebhookConfigForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all organizations, in the order that they were created on GitHub Enterprise Server.
+     *
+     * **Note:** Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of organizations.
+     */
+    list: {
+      (params?: RestEndpointMethodTypes["orgs"]["list"]["parameters"]): Promise<
+        RestEndpointMethodTypes["orgs"]["list"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all GitHub Apps in an organization. The installation count includes all GitHub Apps installed on repositories in the organization. You must be an organization owner with `admin:read` scope to use this endpoint.
+     */
+    listAppInstallations: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listAppInstallations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listAppInstallations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List organizations for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * This only lists organizations that your authorization allows you to operate on in some way (e.g., you can list teams with `read:org` scope, you can publicize your organization membership with `user` scope, etc.). Therefore, this API requires at least `user` or `read:org` scope. OAuth requests with insufficient scope receive a `403 Forbidden` response.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List [public organization memberships](https://help.github.com/articles/publicizing-or-concealing-organization-membership) for the specified user.
+     *
+     * This method only lists _public_ memberships, regardless of authentication. If you need to fetch all of the organization memberships (public and private) for the authenticated user, use the [List organizations for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/orgs#list-organizations-for-the-authenticated-user) API instead.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
+     */
+    listMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembers"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listMembers"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listMembershipsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listMembershipsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all users who are outside collaborators of an organization.
+     */
+    listOutsideCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listOutsideCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Members of an organization can choose to have their membership publicized or not.
+     */
+    listPublicMembers: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listPublicMembers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["listPublicMembers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@3.0/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all teams and they will no longer have any access to the organization's repositories.
+     */
+    removeMember: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMember"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["removeMember"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * In order to remove a user's membership with an organization, the authenticated user must be an organization owner.
+     *
+     * If the specified user is an active member of the organization, this will remove them from the organization. If the specified user has been invited to the organization, this will cancel their invitation. The specified user will receive an email notification in both cases.
+     */
+    removeMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removing a user from this list will remove them from all the organization's repositories.
+     */
+    removeOutsideCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removeOutsideCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removePublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["removePublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Only authenticated organization owners can add a member to the organization or update the member's role.
+     *
+     * *   If the authenticated user is _adding_ a member to the organization, the invited user will receive an email inviting them to the organization. The user's [membership status](https://docs.github.com/enterprise-server@3.0/rest/reference/orgs#get-organization-membership-for-a-user) will be `pending` until they accept the invitation.
+     *
+     * *   Authenticated users can _update_ a user's membership by passing the `role` parameter. If the authenticated user changes a member's role to `admin`, the affected user will receive an email notifying them that they've been made an organization owner. If the authenticated user changes an owner's role to `member`, no email will be sent.
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, the authenticated user is limited to 50 organization invitations per 24 hour period. If the organization is more than one month old or on a paid plan, the limit is 500 invitations per 24 hour period.
+     */
+    setMembershipForUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setMembershipForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The user can publicize their own membership. (A user cannot publicize the membership for another user.)
+     *
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     */
+    setPublicMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["setPublicMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Parameter Deprecation Notice:** GitHub Enterprise Server will replace and discontinue `members_allowed_repository_creation_type` in favor of more granular permissions. The new input parameters are `members_can_create_public_repositories`, `members_can_create_private_repositories` for all organizations and `members_can_create_internal_repositories` for organizations associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. For more information, see the [blog post](https://developer.github.com/changes/2019-12-03-internal-visibility-changes).
+     *
+     * Enables an authenticated organization owner with the `admin:org` scope to update the organization's profile and member privileges.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateMembershipForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateMembershipForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in an organization. When you update a webhook, the `secret` will be overwritten. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for an organization](/rest/reference/orgs#update-a-webhook-configuration-for-an-organization)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["orgs"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the webhook configuration for an organization. To update more information about the webhook, including the `active` state and `events`, use "[Update an organization webhook ](/rest/reference/orgs#update-an-organization-webhook)."
+     *
+     * Access tokens must have the `admin:org_hook` scope, and GitHub Apps must have the `organization_hooks:write` permission.
+     */
+    updateWebhookConfigForOrg: {
+      (
+        params?: RestEndpointMethodTypes["orgs"]["updateWebhookConfigForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["orgs"]["updateWebhookConfigForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  projects: {
+    /**
+     * Adds a collaborator to an organization project and sets their permission level. You must be an organization owner or a project `admin` to add a collaborator.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["createCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates an organization project board. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a repository project board. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    createForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["createForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["createForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a project board. Returns a `404 Not Found` status if projects are disabled.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["deleteCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["deleteColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["deleteColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a project by its `id`. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["getColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the collaborator's permission level for an organization project. Possible values for the `permission` key: `admin`, `write`, `read`, `none`. You must be an organization owner or a project `admin` to review a user's permission level.
+     */
+    getPermissionForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["getPermissionForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["getPermissionForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listCards: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCards"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listCards"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listColumns: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listColumns"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listColumns"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    listForRepo: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["listForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["listForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    moveColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["moveColumn"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["moveColumn"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a collaborator from an organization project. You must be an organization owner or a project `admin` to remove a collaborator.
+     */
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a project board's information. Returns a `404 Not Found` status if projects are disabled. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCard: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateCard"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["projects"]["updateCard"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateColumn: {
+      (
+        params?: RestEndpointMethodTypes["projects"]["updateColumn"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["projects"]["updateColumn"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  pulls: {
+    checkIfMerged: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["checkIfMerged"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["checkIfMerged"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+     *
+     * You can create a new pull request.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a reply to a review comment for a pull request. For the `comment_id`, provide the ID of the review comment you are replying to. This must be the ID of a _top-level review comment_, not a reply to that comment. Replies to replies are not supported.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReplyForReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReplyForReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * Pull request reviews created in the `PENDING` state do not include the `submitted_at` property in the response.
+     *
+     * **Note:** To comment on a specific line in a file, you need to first determine the _position_ of that line in the diff. The GitHub REST API v3 offers the `application/vnd.github.v3.diff` [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types#commits-commit-comparison-and-pull-requests). To see a pull request diff, add this media type to the `Accept` header of a call to the [single pull request](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#get-a-pull-request) endpoint.
+     *
+     * The `position` value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     */
+    createReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["createReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a review comment in the pull request diff. To add a regular comment to a pull request timeline, see "[Create an issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#create-an-issue-comment)." We recommend creating a review comment using `line`, `side`, and optionally `start_line` and `start_side` if your comment applies to more than one line in the pull request diff.
+     *
+     * You can still create a review comment using the `position` parameter. When you use `position`, the `line`, `side`, `start_line`, and `start_side` parameters are not required. For more information, see the [`comfort-fade` preview notice](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#create-a-review-comment-for-a-pull-request-preview-notices).
+     *
+     * **Note:** The position value equals the number of lines down from the first "@@" hunk header in the file you want to add a comment. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks until the beginning of a new file.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["createReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["createReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePendingReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deletePendingReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deletePendingReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a review comment.
+     */
+    deleteReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["deleteReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** To dismiss a pull request review on a [protected branch](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#branches), you must be a repository administrator or be included in the list of people or teams who can dismiss pull request reviews.
+     */
+    dismissReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["dismissReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["dismissReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists details of a pull request by providing its number.
+     *
+     * When you get, [create](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls/#create-a-pull-request), or [edit](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#update-a-pull-request) a pull request, GitHub Enterprise Server creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/enterprise-server@3.0/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
+     *
+     * The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub Enterprise Server has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the _test_ merge commit.
+     *
+     * The value of the `merge_commit_sha` attribute changes depending on the state of the pull request. Before merging a pull request, the `merge_commit_sha` attribute holds the SHA of the _test_ merge commit. After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
+     *
+     * *   If merged as a [merge commit](https://help.github.com/articles/about-merge-methods-on-github/), `merge_commit_sha` represents the SHA of the merge commit.
+     * *   If merged via a [squash](https://help.github.com/articles/about-merge-methods-on-github/#squashing-your-merge-commits), `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
+     * *   If [rebased](https://help.github.com/articles/about-merge-methods-on-github/#rebasing-and-merging-your-commits), `merge_commit_sha` represents the commit that the base branch was updated to.
+     *
+     * Pass the appropriate [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["pulls"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["pulls"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["getReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides details for a review comment.
+     */
+    getReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["getReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["getReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List comments for a specific pull request review.
+     */
+    listCommentsForReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listCommentsForReview"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a maximum of 250 commits for a pull request. To receive a complete commit list for pull requests with more than 250 commits, use the [List commits](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-commits) endpoint.
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** Responses include a maximum of 3000 files. The paginated response returns 30 files per page by default.
+     */
+    listFiles: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listFiles"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
+     */
+    listReviewComments: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewComments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
+     */
+    listReviewCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["listReviewCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The list of reviews returns in chronological order.
+     */
+    listReviews: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["listReviews"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@3.0/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeRequestedReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["removeRequestedReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/enterprise-server@3.0/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits)" for details.
+     */
+    requestReviewers: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["requestReviewers"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["requestReviewers"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    submitReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["submitReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["submitReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To open or update a pull request in a public repository, you must have write access to the head or the source branch. For organization-owned repositories, you must be a member of the organization that owns the repository to open or update a pull request.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch.
+     */
+    updateBranch: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Update the review summary comment with new text.
+     */
+    updateReview: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReview"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["pulls"]["updateReview"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Enables you to edit a review comment.
+     */
+    updateReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["pulls"]["updateReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["pulls"]["updateReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  rateLimit: {
+    /**
+     * **Note:** Accessing this endpoint does not count against your REST API rate limit.
+     *
+     * **Note:** The `rate` object is deprecated. If you're writing new API client code or updating existing code, you should use the `core` object instead of the `rate` object. The `core` object contains the same information that is present in the `rate` object.
+     */
+    get: {
+      (
+        params?: RestEndpointMethodTypes["rateLimit"]["get"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["rateLimit"]["get"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  reactions: {
+    /**
+     * Create a reaction to a [commit comment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#comments). A response with an HTTP `200` status means that you already added the reaction type to this commit comment.
+     */
+    createForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue](https://docs.github.com/enterprise-server@3.0/rest/reference/issues/). A response with an HTTP `200` status means that you already added the reaction type to this issue.
+     */
+    createForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to an [issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#comments). A response with an HTTP `200` status means that you already added the reaction type to this issue comment.
+     */
+    createForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#comments). A response with an HTTP `200` status means that you already added the reaction type to this pull request review comment.
+     */
+    createForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion comment.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    createForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a reaction to a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/). A response with an HTTP `200` status means that you already added the reaction type to this team discussion.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    createForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["createForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [commit comment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#comments).
+     */
+    deleteForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/issues/:issue_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue](https://docs.github.com/enterprise-server@3.0/rest/reference/issues/).
+     */
+    deleteForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE delete /repositories/:repository_id/issues/comments/:comment_id/reactions/:reaction_id`.
+     *
+     * Delete a reaction to an [issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#comments).
+     */
+    deleteForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a repository by `repository_id` using the route `DELETE /repositories/:repository_id/pulls/comments/:comment_id/reactions/:reaction_id.`
+     *
+     * Delete a reaction to a [pull request review comment](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#review-comments).
+     */
+    deleteForPullRequestComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForPullRequestComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussion: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussion"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** You can also specify a team or organization with `team_id` and `org_id` using the route `DELETE /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions/:reaction_id`.
+     *
+     * Delete a reaction to a [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments). OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteForTeamDiscussionComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteForTeamDiscussionComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecation Notice:** This endpoint route is deprecated and will be removed from the Reactions API. We recommend migrating your existing code to use the new delete reactions endpoints. For more information, see this [blog post](https://developer.github.com/changes/2020-02-26-new-delete-reactions-endpoints/).
+     *
+     * OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), when deleting a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions) or [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments).
+     * @deprecated octokit.rest.reactions.deleteLegacy() is deprecated, see https://docs.github.com/enterprise-server@3.0/rest/reference/reactions/#delete-a-reaction-legacy
+     */
+    deleteLegacy: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["deleteLegacy"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["deleteLegacy"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [commit comment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#comments).
+     */
+    listForCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue](https://docs.github.com/enterprise-server@3.0/rest/reference/issues).
+     */
+    listForIssue: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssue"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssue"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to an [issue comment](https://docs.github.com/enterprise-server@3.0/rest/reference/issues#comments).
+     */
+    listForIssueComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForIssueComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForIssueComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [pull request review comment](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#review-comments).
+     */
+    listForPullRequestReviewComment: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForPullRequestReviewComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion comment](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussion-comments/). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
+     */
+    listForTeamDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List the reactions to a [team discussion](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#discussions). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
+     */
+    listForTeamDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["reactions"]["listForTeamDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  repos: {
+    acceptInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["acceptInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["acceptInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified apps push access for this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * For more information the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     *
+     * Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * The invitee will receive a notification that they have been invited to the repository, which they must accept or decline. They may do this via the notifications page, the email they receive, or by using the [repository invitations API endpoints](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#invitations).
+     *
+     * **Rate limits**
+     *
+     * To prevent abuse, you are limited to sending 50 invitations to a repository per 24 hour period. Note there is no limit if you are inviting organization members to an organization repository.
+     */
+    addCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    addStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified teams push access for this branch. You can also give push access to child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Grants the specified people push access for this branch.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    addUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["addUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    checkCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["checkCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["checkCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Deprecated**: Use `repos.compareCommitsWithBasehead()` (`GET /repos/{owner}/{repo}/compare/{basehead}`) instead. Both `:base` and `:head` must be branch names in `:repo`. To compare branches across other repositories in the same network as `:repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * To process a response with a large number of commits, you can use (`per_page` or `page`) to paginate the results. When using paging, the list of changed files is only returned with page 1, but includes all changed files for the entire comparison. For more information on working with pagination, see "[Traversing with pagination](/rest/guides/traversing-with-pagination)."
+     *
+     * When calling this API without any paging parameters (`per_page` or `page`), the returned list is limited to 250 commits and the last commit in the list is the most recent of the entire comparison. When a paging parameter is specified, the first commit in the returned list of each page is the earliest.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommits"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommits"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * The `basehead` param is comprised of two parts: `base` and `head`. Both must be branch names in `repo`. To compare branches across other repositories in the same network as `repo`, use the format `<USERNAME>:branch`.
+     *
+     * The response from the API is equivalent to running the `git log base..head` command; however, commits are returned in chronological order. Pass the appropriate [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to fetch diff and patch formats.
+     *
+     * The response also includes details on the files that were changed between the two commits. This includes the status of the change (for example, if a file was added, removed, modified, or renamed), and details of the change itself. For example, files with a `renamed` status have a `previous_filename` field showing the previous filename of the file, and files with a `modified` status have a `patch` field showing the changes made to the file.
+     *
+     * **Working with large comparisons**
+     *
+     * The response will include a comparison of up to 250 commits. If you are working with a larger commit range, you can use the [List commits](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-commits) to enumerate all commits in the range.
+     *
+     * For comparisons with extremely large diffs, you may receive an error response indicating that the diff took too long
+     * to generate. You can typically resolve this error by using a smaller commit range.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    compareCommitsWithBasehead: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a comment for a commit using its `:commit_sha`.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to require signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    createCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access in a repository can create commit statuses for a given SHA.
+     *
+     * Note: there is a limit of 1000 statuses per `sha` and `context` within a repository. Attempts to create more than 1000 statuses will result in a validation error.
+     */
+    createCommitStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createCommitStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can create a read-only deploy key.
+     */
+    createDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deployments offer a few configurable parameters with certain defaults.
+     *
+     * The `ref` parameter can be any named branch, tag, or SHA. At GitHub Enterprise Server we often deploy branches and verify them
+     * before we merge a pull request.
+     *
+     * The `environment` parameter allows deployments to be issued to different runtime environments. Teams often have
+     * multiple environments for verifying their applications, such as `production`, `staging`, and `qa`. This parameter
+     * makes it easier to track which environments have requested deployments. The default environment is `production`.
+     *
+     * The `auto_merge` parameter is used to ensure that the requested ref is not behind the repository's default branch. If
+     * the ref _is_ behind the default branch for the repository, we will attempt to merge it for you. If the merge succeeds,
+     * the API will return a successful merge commit. If merge conflicts prevent the merge from succeeding, the API will
+     * return a failure response.
+     *
+     * By default, [commit statuses](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#statuses) for every submitted context must be in a `success`
+     * state. The `required_contexts` parameter allows you to specify a subset of contexts that must be `success`, or to
+     * specify contexts that have not yet been submitted. You are not required to use commit statuses to deploy. If you do
+     * not require any contexts or create any commit statuses, the deployment will always succeed.
+     *
+     * The `payload` parameter is available for any extra information that a deployment system might need. It is a JSON text
+     * field that will be passed on when a deployment event is dispatched.
+     *
+     * The `task` parameter is used by the deployment system to allow different execution paths. In the web world this might
+     * be `deploy:migrations` to run schema changes on the system. In the compiled world this could be a flag to compile an
+     * application with debugging enabled.
+     *
+     * Users with `repo` or `repo_deployment` scopes can create a deployment for a given ref.
+     *
+     * #### Merged branch response
+     * You will see this response when GitHub automatically merges the base branch into the topic branch instead of creating
+     * a deployment. This auto-merge happens when:
+     * *   Auto-merge option is enabled in the repository
+     * *   Topic branch does not include the latest changes on the base branch, which is `master` in the response example
+     * *   There are no merge conflicts
+     *
+     * If there are no new commits in the base branch, a new request to create a deployment should give a successful
+     * response.
+     *
+     * #### Merge conflict response
+     * This error happens when the `auto_merge` option is enabled and when the default branch (in this case `master`), can't
+     * be merged into the branch that's being deployed (in this case `topic-branch`), due to merge conflicts.
+     *
+     * #### Failed commit status checks
+     * This error happens when the `required_contexts` parameter indicates that one or more contexts need to have a `success`
+     * status for the commit to be deployed, but one or more of the required contexts do not have a state of `success`.
+     */
+    createDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with `push` access can create deployment statuses for a given deployment.
+     *
+     * GitHub Apps require `read & write` access to "Deployments" and `read-only` access to "Repo contents" (for private repos). OAuth Apps require the `repo_deployment` scope.
+     */
+    createDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can use this endpoint to trigger a webhook event called `repository_dispatch` when you want activity that happens outside of GitHub Enterprise Server to trigger a GitHub Actions workflow or GitHub App webhook. You must configure your GitHub Actions workflow or GitHub App to run when the `repository_dispatch` event occurs. For an example `repository_dispatch` webhook payload, see "[RepositoryDispatchEvent](https://docs.github.com/enterprise-server@3.0/webhooks/event-payloads/#repository_dispatch)."
+     *
+     * The `client_payload` parameter is available for any extra information that your workflow might need. This parameter is a JSON payload that will be passed on when the webhook event is dispatched. For example, the `client_payload` can include a message that a user would like to send using a GitHub Actions workflow. Or the `client_payload` can be used as a test to debug your workflow.
+     *
+     * This endpoint requires write access to the repository by providing either:
+     *
+     *   - Personal access tokens with `repo` scope. For more information, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)" in the GitHub Help documentation.
+     *   - GitHub Apps with both `metadata:read` and `contents:read&write` permissions.
+     *
+     * This input example shows how you can use the `client_payload` as a test to debug your workflow.
+     */
+    createDispatchEvent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createDispatchEvent"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createDispatchEvent"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository for the authenticated user.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository.
+     */
+    createForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Create a fork for the authenticated user.
+     *
+     * **Note**: Forking a Repository happens asynchronously. You may have to wait a short period of time before you can access the git objects. If this takes longer than 5 minutes, be sure to contact [GitHub Enterprise Server Support](https://support.github.com/contact) or [GitHub Enterprise Server Premium Support](https://premium.githubsupport.com).
+     */
+    createFork: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createFork"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createFork"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository in the specified organization. The authenticated user must be a member of the organization.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createInOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new file or replaces an existing file in a repository.
+     */
+    createOrUpdateFileContents: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createOrUpdateFileContents"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Configures a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages)."
+     */
+    createPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can create a release.
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     */
+    createRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new repository using a repository template. Use the `template_owner` and `template_repo` route parameters to specify the repository to use as the template. The authenticated user must own or be a member of an organization that owns the repository. To check if a repository is available to use as a template, get the repository's information using the [Get a repository](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#get-a-repository) endpoint and check that the `is_template` key is `true`.
+     *
+     * **OAuth scope requirements**
+     *
+     * When using [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/), authorizations must include:
+     *
+     * *   `public_repo` scope or `repo` scope to create a public repository. Note: For GitHub AE, use `repo` scope to create an internal repository.
+     * *   `repo` scope to create a private repository
+     */
+    createUsingTemplate: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createUsingTemplate"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["createUsingTemplate"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Repositories can have multiple webhooks installed. Each webhook should have a unique `config`. Multiple webhooks can
+     * share the same `config` as long as those webhooks do not have any `events` that overlap.
+     */
+    createWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["createWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["createWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    declineInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["declineInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["declineInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+     *
+     * If an organization owner has configured the organization to prevent members from deleting organization-owned
+     * repositories, you will get a `403 Forbidden` response.
+     */
+    delete: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["delete"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["delete"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Disables the ability to restrict who can push to this branch.
+     */
+    deleteAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removing admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    deleteAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deleteBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to disable required signed commits on a branch. You must enable branch protection to require signed commits.
+     */
+    deleteCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
+     */
+    deleteDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployKey"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployKey"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To ensure there can always be an active deployment, you can only delete an _inactive_ deployment. Anyone with `repo` or `repo_deployment` scopes can delete an inactive deployment.
+     *
+     * To set a deployment as inactive, you must:
+     *
+     * *   Create a new deployment that is active so that the system has a record of the current state, then delete the previously active deployment.
+     * *   Mark the active deployment as inactive by adding any non-successful deployment status.
+     *
+     * For more information, see "[Create a deployment](https://docs.github.com/enterprise-server@3.0/rest/reference/repos/#create-a-deployment)" and "[Create a deployment status](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#create-a-deployment-status)."
+     */
+    deleteDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteDeployment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteDeployment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a file in a repository.
+     *
+     * You can provide an additional `committer` parameter, which is an object containing information about the committer. Or, you can provide an `author` parameter, which is an object containing information about the author.
+     *
+     * The `author` section is optional and is filled in with the `committer` information if omitted. If the `committer` information is omitted, the authenticated user's information is used.
+     *
+     * You must provide values for both `name` and `email`, whether you choose to use `author` or `committer`. Otherwise, you'll receive a `422` status code.
+     */
+    deleteFile: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteFile"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteFile"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deletePagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    deletePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deletePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can delete a release.
+     */
+    deleteRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["deleteReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    deleteWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["deleteWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["deleteWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a tar archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadTarballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadTarballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a redirect URL to download a zip archive for a repository. If you omit `:ref`, the repository’s default branch (usually
+     * `master`) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use
+     * the `Location` header to make a second `GET` request.
+     * **Note**: For private repositories, these links are temporary and expire after five minutes.
+     */
+    downloadZipballArchive: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["downloadZipballArchive"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When you pass the `scarlet-witch-preview` media type, requests to get a repository will also return the repository's code of conduct if it can be detected from the repository's code of conduct file.
+     *
+     * The `parent` and `source` objects are present when the repository is a fork. `parent` is the repository this repository was forked from, `source` is the ultimate source for the network.
+     */
+    get: {
+      (params?: RestEndpointMethodTypes["repos"]["get"]["parameters"]): Promise<
+        RestEndpointMethodTypes["repos"]["get"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists who has access to this protected branch.
+     *
+     * **Note**: Users, apps, and teams `restrictions` are only available for organization-owned repositories.
+     */
+    getAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getAllStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAllStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAllTopics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getAllTopics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the GitHub Apps that have push access to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     */
+    getAppsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getAppsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranch"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getBranch"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
+     */
+    getCodeFrequencyStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCodeFrequencyStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks the repository permission of a collaborator. The possible repository permissions are `admin`, `write`, `read`, and `none`.
+     */
+    getCollaboratorPermissionLevel: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCollaboratorPermissionLevel"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can access a combined view of commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name.
+     *
+     * The most recent status for each context is returned, up to 100. This field [paginates](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination) if there are over 100 contexts.
+     *
+     * Additionally, a combined `state` is returned. The `state` is one of:
+     *
+     * *   **failure** if any of the contexts report as `error` or `failure`
+     * *   **pending** if there are no statuses or a context is `pending`
+     * *   **success** if the latest status for all contexts is `success`
+     */
+    getCombinedStatusForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCombinedStatusForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the contents of a single commit reference. You must have `read` access for the repository to use this endpoint.
+     *
+     * **Note:** If there are more than 300 files in the commit diff, the response will include pagination link headers for the remaining files, up to a limit of 3000 files. Each page contains the static commit information, and the only changes are to the file listing.
+     *
+     * You can pass the appropriate [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) to  fetch `diff` and `patch` formats. Diffs with binary data will have no `patch` property.
+     *
+     * To return only the SHA-1 hash of the commit reference, you can provide the `sha` custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/#commits-commit-comparison-and-pull-requests) in the `Accept` header. You can use this endpoint to check if a remote reference's SHA-1 hash is the same as your local reference's SHA-1 hash by providing the local SHA-1 reference as the ETag.
+     *
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    getCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommit"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getCommit"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the last year of commit activity grouped by week. The `days` array is a group of commits per day, starting on `Sunday`.
+     */
+    getCommitActivityStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * When authenticated with admin or owner permissions to the repository, you can use this endpoint to check whether a branch requires signed commits. An enabled status of `true` indicates you must sign commits on this branch. For more information, see [Signing commits with GPG](https://help.github.com/articles/signing-commits-with-gpg) in GitHub Help.
+     *
+     * **Note**: You must enable branch protection to require signed commits.
+     */
+    getCommitSignatureProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getCommitSignatureProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the contents of a file or directory in a repository. Specify the file path or directory in `:path`. If you omit
+     * `:path`, you will receive the contents of the repository's root directory. See the description below regarding what the API response includes for directories.
+     *
+     * Files and symlinks support [a custom media type](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) for
+     * retrieving the raw content or rendered HTML (when supported). All content types support [a custom media
+     * type](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) to ensure the content is returned in a consistent
+     * object format.
+     *
+     * **Note**:
+     * *   To get a repository's contents recursively, you can [recursively get the tree](https://docs.github.com/enterprise-server@3.0/rest/reference/git#trees).
+     * *   This API has an upper limit of 1,000 files for a directory. If you need to retrieve more files, use the [Git Trees
+     * API](https://docs.github.com/enterprise-server@3.0/rest/reference/git#get-a-tree).
+     * *   This API supports files up to 1 megabyte in size.
+     *
+     * #### If the content is a directory
+     * The response will be an array of objects, one object for each item in the directory.
+     * When listing the contents of a directory, submodules have their "type" specified as "file". Logically, the value
+     * _should_ be "submodule". This behavior exists in API v3 [for backwards compatibility purposes](https://git.io/v1YCW).
+     * In the next major version of the API, the type will be returned as "submodule".
+     *
+     * #### If the content is a symlink
+     * If the requested `:path` points to a symlink, and the symlink's target is a normal file in the repository, then the
+     * API responds with the content of the file (in the format shown in the example. Otherwise, the API responds with an object
+     * describing the symlink itself.
+     *
+     * #### If the content is a submodule
+     * The `submodule_git_url` identifies the location of the submodule repository, and the `sha` identifies a specific
+     * commit within the submodule repository. Git uses the given URL when cloning the submodule repository, and checks out
+     * the submodule at that specific commit.
+     *
+     * If the submodule repository is not hosted on github.com, the Git URLs (`git_url` and `_links["git"]`) and the
+     * github.com URLs (`html_url` and `_links["html"]`) will have null values.
+     */
+    getContent: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContent"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getContent"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the `total` number of commits authored by the contributor. In addition, the response includes a Weekly Hash (`weeks` array) with the following information:
+     *
+     * *   `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+     * *   `a` - Number of additions
+     * *   `d` - Number of deletions
+     * *   `c` - Number of commits
+     */
+    getContributorsStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getContributorsStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getContributorsStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployKey: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployKey"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployKey"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getDeployment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeployment"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getDeployment"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view a deployment status for a deployment:
+     */
+    getDeploymentStatus: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getDeploymentStatus"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getLatestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View the latest published full release for the repository.
+     *
+     * The latest release is the most recent non-prerelease, non-draft release, sorted by the `created_at` attribute. The `created_at` attribute is the date of the commit used for the release, and not the date when the release was drafted or published.
+     */
+    getLatestRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getLatestRelease"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getLatestRelease"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    getPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPagesBuild"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getPagesBuild"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the total commit counts for the `owner` and total commit counts in `all`. `all` is everyone combined, including the `owner` in the last 52 weeks. If you'd like to get the commit counts for non-owners, you can subtract `owner` from `all`.
+     *
+     * The array order is oldest week (index 0) to most recent week.
+     */
+    getParticipationStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getParticipationStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getParticipationStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getPullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Each array contains the day number, hour number, and number of commits:
+     *
+     * *   `0-6`: Sunday - Saturday
+     * *   `0-23`: Hour of day
+     * *   Number of commits
+     *
+     * For example, `[2, 14, 25]` indicates that there were 25 total commits, during the 2:00pm hour on Tuesdays. All times are based on the time zone of individual commits.
+     */
+    getPunchCardStats: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getPunchCardStats"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getPunchCardStats"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the preferred README for a repository.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadme: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadme"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getReadme"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets the README from a repository directory.
+     *
+     * READMEs support [custom media types](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
+     */
+    getReadmeInDirectory: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReadmeInDirectory"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** This returns an `upload_url` key corresponding to the endpoint for uploading release assets. This key is a [hypermedia resource](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#hypermedia).
+     */
+    getRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response.
+     */
+    getReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a published release with the specified tag.
+     */
+    getReleaseByTag: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getReleaseByTag"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    getStatusChecksProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getStatusChecksProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the teams who have push access to this branch. The list includes child teams.
+     */
+    getTeamsWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getTeamsWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Lists the people who have push access to this branch.
+     */
+    getUsersWithAccessToProtectedBranch: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getUsersWithAccessToProtectedBranch"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns a webhook configured in a repository. To get only the webhook `config` properties, see "[Get a webhook configuration for a repository](/rest/reference/repos#get-a-webhook-configuration-for-a-repository)."
+     */
+    getWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["getWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Returns the webhook configuration for a repository. To get more information about the webhook, including the `active` state and `events`, use "[Get a repository webhook](/rest/reference/orgs#get-a-repository-webhook)."
+     *
+     * Access tokens must have the `read:repo_hook` or `repo` scope, and GitHub Apps must have the `repository_hooks:read` permission.
+     */
+    getWebhookConfigForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["getWebhookConfigForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["getWebhookConfigForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listBranches: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranches"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listBranches"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Returns all branches where the given commit SHA is the HEAD, or latest commit for the branch.
+     */
+    listBranchesForHeadCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listBranchesForHeadCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * For organization-owned repositories, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners.
+     *
+     * Team members will include the members of child teams.
+     */
+    listCollaborators: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCollaborators"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCollaborators"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Use the `:commit_sha` to specify the commit that will have its comments listed.
+     */
+    listCommentsForCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommentsForCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Commit Comments use [these custom media types](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#custom-media-types). You can read more about the use of media types in the API [here](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/).
+     *
+     * Comments are ordered by ascending ID.
+     */
+    listCommitCommentsForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitCommentsForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access in a repository can view commit statuses for a given ref. The ref can be a SHA, a branch name, or a tag name. Statuses are returned in reverse chronological order. The first status in the list will be the latest one.
+     *
+     * This resource is also available via a legacy route: `GET /repos/:owner/:repo/statuses/:ref`.
+     */
+    listCommitStatusesForRef: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Signature verification object**
+     *
+     * The response will include a `verification` object that describes the result of verifying the commit's signature. The following fields are included in the `verification` object:
+     *
+     * | Name | Type | Description |
+     * | ---- | ---- | ----------- |
+     * | `verified` | `boolean` | Indicates whether GitHub considers the signature in this commit to be verified. |
+     * | `reason` | `string` | The reason for verified value. Possible values and their meanings are enumerated in table below. |
+     * | `signature` | `string` | The signature that was extracted from the commit. |
+     * | `payload` | `string` | The value that was signed. |
+     *
+     * These are the possible values for `reason` in the `verification` object:
+     *
+     * | Value | Description |
+     * | ----- | ----------- |
+     * | `expired_key` | The key that made the signature is expired. |
+     * | `not_signing_key` | The "signing" flag is not among the usage flags in the GPG key that made the signature. |
+     * | `gpgverify_error` | There was an error communicating with the signature verification service. |
+     * | `gpgverify_unavailable` | The signature verification service is currently unavailable. |
+     * | `unsigned` | The object does not include a signature. |
+     * | `unknown_signature_type` | A non-PGP signature was found in the commit. |
+     * | `no_user` | No user was associated with the `committer` email address in the commit. |
+     * | `unverified_email` | The `committer` email address in the commit was associated with a user, but the email address is not verified on her/his account. |
+     * | `bad_email` | The `committer` email address in the commit is not included in the identities of the PGP key that made the signature. |
+     * | `unknown_key` | The key that made the signature has not been registered with any user's account. |
+     * | `malformed_signature` | There was an error parsing the signature. |
+     * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
+     * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
+     */
+    listCommits: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listCommits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listCommits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists contributors to the specified repository and sorts them by the number of commits per contributor in descending order. This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
+     *
+     * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
+     */
+    listContributors: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listContributors"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listContributors"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listDeployKeys: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployKeys"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployKeys"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with pull access can view deployment statuses for a deployment:
+     */
+    listDeploymentStatuses: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeploymentStatuses"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Simple filtering of deployments is available via query parameters:
+     */
+    listDeployments: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listDeployments"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listDeployments"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories that the authenticated user has explicit permission (`:read`, `:write`, or `:admin`) to access.
+     *
+     * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists repositories for the specified organization.
+     */
+    listForOrg: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists public repositories for the specified user. Note: For GitHub AE, this endpoint will list internal repositories for the specified user.
+     */
+    listForUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForUser"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForUser"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listForks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listForks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listForks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user with admin rights to a repository, this endpoint will list all currently open repository invitations.
+     */
+    listInvitations: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitations"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitations"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * When authenticating as a user, this endpoint will list all currently open repository invitations for that user.
+     */
+    listInvitationsForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listInvitationsForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists languages for the specified repository. The value shown for each language is the number of bytes of code written in that language.
+     */
+    listLanguages: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listLanguages"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listLanguages"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listPagesBuilds: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPagesBuilds"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPagesBuilds"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all public repositories in the order that they were created.
+     *
+     * Note:
+     * - For GitHub Enterprise Server, this endpoint will only list repositories available to all users on the enterprise.
+     * - Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of repositories.
+     */
+    listPublic: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPublic"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listPublic"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, additionally returns open pull requests associated with the commit. The results may include open and closed pull requests. Additional preview headers may be required to see certain details for associated pull requests, such as whether a pull request is in a draft state. For more information about previews that might affect this endpoint, see the [List pull requests](https://docs.github.com/enterprise-server@3.0/rest/reference/pulls#list-pull-requests) endpoint.
+     */
+    listPullRequestsAssociatedWithCommit: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listPullRequestsAssociatedWithCommit"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listReleaseAssets: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleaseAssets"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the [Repository Tags API](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-repository-tags).
+     *
+     * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+     */
+    listReleases: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listReleases"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listReleases"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTags: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTags"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTags"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listTeams: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listTeams"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listTeams"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    listWebhooks: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["listWebhooks"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["listWebhooks"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    merge: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["merge"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["merge"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger a [ping event](https://docs.github.com/enterprise-server@3.0/webhooks/#ping-event) to be sent to the hook.
+     */
+    pingWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["pingWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["pingWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of an app to push to this branch. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    removeCollaborator: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeCollaborator"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeCollaborator"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    removeStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a team to push to this branch. You can also remove push access for child teams.
+     *
+     * | Type    | Description                                                                                                                                         |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Teams that should no longer have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Removes the ability of a user to push to this branch.
+     *
+     * | Type    | Description                                                                                                                                   |
+     * | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames of the people who should no longer have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    removeUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["removeUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    replaceAllTopics: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["replaceAllTopics"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["replaceAllTopics"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * You can request that your site be built from the latest revision on the default branch. This has the same effect as pushing a commit to your default branch, but does not require an additional commit. Manually triggering page builds can be helpful when diagnosing build warnings and failures.
+     *
+     * Build requests are limited to one concurrent build per repository and one concurrent build per requester. If you request a build while another is still in progress, the second request will be queued until the first completes.
+     */
+    requestPagesBuild: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["requestPagesBuild"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["requestPagesBuild"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adding admin enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    setAdminBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAdminBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of apps that have push access to this branch. This removes all apps that previously had push access and grants push access to the new list of apps. Only installed GitHub Apps with `write` access to the `contents` permission can be added as authorized actors on a protected branch.
+     *
+     * | Type    | Description                                                                                                                                                |
+     * | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | The GitHub Apps that have push access to this branch. Use the app's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setAppAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setAppAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     */
+    setStatusCheckContexts: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setStatusCheckContexts"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of teams that have push access to this branch. This removes all teams that previously had push access and grants push access to the new list of teams. Team restrictions include child teams.
+     *
+     * | Type    | Description                                                                                                                                |
+     * | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+     * | `array` | The teams that can have push access. Use the team's `slug`. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setTeamAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setTeamAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Replaces the list of people that have push access to this branch. This removes all people that previously had push access and grants push access to the new list of people.
+     *
+     * | Type    | Description                                                                                                                   |
+     * | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+     * | `array` | Usernames for people who can have push access. **Note**: The list of users, apps, and teams in total is limited to 100 items. |
+     */
+    setUserAccessRestrictions: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["setUserAccessRestrictions"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This will trigger the hook with the latest push to the current repository if the hook is subscribed to `push` events. If the hook is not subscribed to `push` events, the server will respond with 204 but no test POST will be generated.
+     *
+     * **Note**: Previously `/repos/:owner/:repo/hooks/:hook_id/test`
+     */
+    testPushWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["testPushWebhook"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["testPushWebhook"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * A transfer request will need to be accepted by the new owner when transferring a personal repository to another user. The response will contain the original `owner`, and the transfer will continue asynchronously. For more details on the requirements to transfer personal and organization-owned repositories, see [about repository transfers](https://help.github.com/articles/about-repository-transfers/).
+     */
+    transfer: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["transfer"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["transfer"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note**: To edit a repository's topics, use the [Replace all repository topics](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#replace-all-repository-topics) endpoint.
+     */
+    update: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["update"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["update"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Protecting a branch requires admin or owner permissions to the repository.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     *
+     * **Note**: The list of users, apps, and teams in total is limited to 100 items.
+     */
+    updateBranchProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateBranchProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateBranchProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateCommitComment: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateCommitComment"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateCommitComment"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates information for a GitHub Enterprise Server Pages site. For more information, see "[About GitHub Pages](/github/working-with-github-pages/about-github-pages).
+     */
+    updateInformationAboutPagesSite: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInformationAboutPagesSite"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    updateInvitation: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateInvitation"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateInvitation"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating pull request review enforcement requires admin or owner permissions to the repository and branch protection to be enabled.
+     *
+     * **Note**: Passing new arrays of `users` and `teams` replaces their previous values.
+     */
+    updatePullRequestReviewProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updatePullRequestReviewProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release.
+     */
+    updateRelease: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateRelease"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateRelease"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Users with push access to the repository can edit a release asset.
+     */
+    updateReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Protected branches are available in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Updating required status checks requires admin or owner permissions to the repository and branch protection to be enabled.
+     */
+    updateStatusCheckProtection: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateStatusCheckProtection"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates a webhook configured in a repository. If you previously had a `secret` set, you must provide the same `secret` or set a new `secret` or the secret will be removed. If you are only updating individual webhook `config` properties, use "[Update a webhook configuration for a repository](/rest/reference/repos#update-a-webhook-configuration-for-a-repository)."
+     */
+    updateWebhook: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhook"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["repos"]["updateWebhook"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Updates the webhook configuration for a repository. To update more information about the webhook, including the `active` state and `events`, use "[Update a repository webhook](/rest/reference/orgs#update-a-repository-webhook)."
+     *
+     * Access tokens must have the `write:repo_hook` or `repo` scope, and GitHub Apps must have the `repository_hooks:write` permission.
+     */
+    updateWebhookConfigForRepo: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["updateWebhookConfigForRepo"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["updateWebhookConfigForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint makes use of [a Hypermedia relation](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#hypermedia) to determine which URL to access. The endpoint you call to upload release assets is specific to your release. Use the `upload_url` returned in
+     * the response of the [Create a release endpoint](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#create-a-release) to upload a release asset.
+     *
+     * You need to use an HTTP client which supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this endpoint.
+     *
+     * Most libraries will set the required `Content-Length` header automatically. Use the required `Content-Type` header to provide the media type of the asset. For a list of media types, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). For example:
+     *
+     * `application/zip`
+     *
+     * GitHub Enterprise Server expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body. Everything else about the endpoint is the same as the rest of the API. For example,
+     * you'll still need to pass your authentication to be able to upload an asset.
+     *
+     * When an upstream failure occurs, you will receive a `502 Bad Gateway` status. This may leave an empty asset with a state of `starter`. It can be safely deleted.
+     *
+     * **Notes:**
+     * *   GitHub Enterprise Server renames asset filenames that have special characters, non-alphanumeric characters, and leading or trailing periods. The "[List assets for a release](https://docs.github.com/enterprise-server@3.0/rest/reference/repos#list-assets-for-a-release)"
+     * endpoint lists the renamed filenames. For more information and help, contact [GitHub Enterprise Server Support](https://support.github.com/contact).
+     * *   If you upload an asset with the same filename as another uploaded asset, you'll receive an error and must delete the old file before you can re-upload the new asset.
+     */
+    uploadReleaseAsset: {
+      (
+        params?: RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  search: {
+    /**
+     * Searches for query terms inside of a file. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for code, you can get text match metadata for the file **content** and file **path** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the definition of the `addClass` function inside [jQuery](https://github.com/jquery/jquery) repository, your query would look something like this:
+     *
+     * `q=addClass+in:file+language:js+repo:jquery/jquery`
+     *
+     * This query searches for the keyword `addClass` within a file's contents. The query limits the search to files where the language is JavaScript in the `jquery/jquery` repository.
+     *
+     * #### Considerations for code search
+     *
+     * Due to the complexity of searching code, there are a few restrictions on how searches are performed:
+     *
+     * *   Only the _default branch_ is considered. In most cases, this will be the `master` branch.
+     * *   Only files smaller than 384 KB are searchable.
+     * *   You must always include at least one search term when searching source code. For example, searching for [`language:go`](https://github.com/search?utf8=%E2%9C%93&q=language%3Ago&type=Code) is not valid, while [`amazing
+     * language:go`](https://github.com/search?utf8=%E2%9C%93&q=amazing+language%3Ago&type=Code) is.
+     */
+    code: {
+      (
+        params?: RestEndpointMethodTypes["search"]["code"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["code"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find commits via various criteria on the default branch (usually `master`). This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for commits, you can get text match metadata for the **message** field when you provide the `text-match` media type. For more details about how to receive highlighted search results, see [Text match
+     * metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find commits related to CSS in the [octocat/Spoon-Knife](https://github.com/octocat/Spoon-Knife) repository. Your query would look something like this:
+     *
+     * `q=repo:octocat/Spoon-Knife+css`
+     */
+    commits: {
+      (
+        params?: RestEndpointMethodTypes["search"]["commits"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["commits"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find issues by state and keyword. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for issues, you can get text match metadata for the issue **title**, issue **body**, and issue **comment body** fields when you pass the `text-match` media type. For more details about how to receive highlighted
+     * search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find the oldest unresolved Python bugs on Windows. Your query might look something like this.
+     *
+     * `q=windows+label:bug+language:python+state:open&sort=created&order=asc`
+     *
+     * This query searches for the keyword `windows`, within any open issue that is labeled as `bug`. The search runs across repositories whose primary language is Python. The results are sorted by creation date in ascending order, which means the oldest issues appear first in the search results.
+     *
+     * **Note:** For [user-to-server](https://docs.github.com/developers/apps/identifying-and-authorizing-users-for-github-apps#user-to-server-requests) GitHub App requests, you can't retrieve a combination of issues and pull requests in a single query. Requests that don't include the `is:issue` or `is:pull-request` qualifier will receive an HTTP `422 Unprocessable Entity` response. To get results for both issues and pull requests, you must send separate queries for issues and pull requests. For more information about the `is` qualifier, see "[Searching only issues or pull requests](https://docs.github.com/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-only-issues-or-pull-requests)."
+     */
+    issuesAndPullRequests: {
+      (
+        params?: RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find labels in a repository with names or descriptions that match search keywords. Returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for labels, you can get text match metadata for the label **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to find labels in the `linguist` repository that match `bug`, `defect`, or `enhancement`. Your query might look like this:
+     *
+     * `q=bug+defect+enhancement&repository_id=64778136`
+     *
+     * The labels that best match the query appear first in the search results.
+     */
+    labels: {
+      (
+        params?: RestEndpointMethodTypes["search"]["labels"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["labels"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find repositories via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for repositories, you can get text match metadata for the **name** and **description** fields when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for popular Tetris repositories written in assembly code, your query might look like this:
+     *
+     * `q=tetris+language:assembly&sort=stars&order=desc`
+     *
+     * This query searches for repositories with the word `tetris` in the name, the description, or the README. The results are limited to repositories where the primary language is assembly. The results are sorted by stars in descending order, so that the most popular repositories appear first in the search results.
+     *
+     * When you include the `mercy` preview header, you can also search for multiple topics by adding more `topic:` instances. For example, your query might look like this:
+     *
+     * `q=topic:ruby+topic:rails`
+     */
+    repos: {
+      (
+        params?: RestEndpointMethodTypes["search"]["repos"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["repos"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find topics via various criteria. Results are sorted by best match. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination). See "[Searching topics](https://help.github.com/articles/searching-topics/)" for a detailed list of qualifiers.
+     *
+     * When searching for topics, you can get text match metadata for the topic's **short\_description**, **description**, **name**, or **display\_name** field when you pass the `text-match` media type. For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you want to search for topics related to Ruby that are featured on https://github.com/topics. Your query might look like this:
+     *
+     * `q=ruby+is:featured`
+     *
+     * This query searches for topics with the keyword `ruby` and limits the results to find only topics that are featured. The topics that are the best match for the query appear first in the search results.
+     */
+    topics: {
+      (
+        params?: RestEndpointMethodTypes["search"]["topics"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["topics"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Find users via various criteria. This method returns up to 100 results [per page](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#pagination).
+     *
+     * When searching for users, you can get text match metadata for the issue **login**, **email**, and **name** fields when you pass the `text-match` media type. For more details about highlighting search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata). For more details about how to receive highlighted search results, see [Text match metadata](https://docs.github.com/enterprise-server@3.0/rest/reference/search#text-match-metadata).
+     *
+     * For example, if you're looking for a list of popular users, you might try this query:
+     *
+     * `q=tom+repos:%3E42+followers:%3E1000`
+     *
+     * This query searches for users with the name `tom`. The results are restricted to users with more than 42 repositories and over 1,000 followers.
+     */
+    users: {
+      (
+        params?: RestEndpointMethodTypes["search"]["users"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["search"]["users"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  teams: {
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * Adds an organization member to a team. An authenticated organization owner or team maintainer can add organization members to a team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * An organization owner can add someone who is not part of the team's organization to a team. When an organization owner adds someone to a team who is not an organization member, this endpoint will send an invitation to the person via email. This newly-created membership will be in the "pending" state until the person accepts the invitation, at which point the membership will transition to the "active" state and the user will be added as a member of the team.
+     *
+     * If the user is already a member of the team, this endpoint will update the role of the team member's role. To update the membership of a team member, the authenticated user must be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    addOrUpdateMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds an organization project to a team. To add a project to a team or update the team's permission on a project, the authenticated user must have `admin` permissions for the project. The project and team must be part of the same organization.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    addOrUpdateProjectPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateProjectPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To add a repository to a team or update the team's permission on a repository, the authenticated user must have admin access to the repository, and must be able to see the team. The repository must be owned by the organization, or a direct fork of a repository owned by the organization. You will get a `422 Unprocessable Entity` status if you attempt to add a repository to a team that is not owned by the organization. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PUT /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     *
+     * For more information about the permission levels, see "[Repository permission levels for an organization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization)".
+     */
+    addOrUpdateRepoPermissionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["addOrUpdateRepoPermissionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `read`, `write`, or `admin` permissions for an organization project. The response includes projects inherited from a parent team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    checkPermissionsForProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Checks whether a team has `admin`, `push`, `maintain`, `triage`, or `pull` permission for a repository. Repositories inherited through a parent team will also be checked.
+     *
+     * You can also get information about the specified repository, including what permissions the team grants on it, by passing the following custom [media type](https://docs.github.com/enterprise-server@3.0/rest/overview/media-types/) via the `application/vnd.github.v3.repository+json` accept header.
+     *
+     * If a team doesn't have permission for the repository, you will receive a `404 Not Found` response status.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    checkPermissionsForRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["checkPermissionsForRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams. Organization owners can limit team creation to organization owners. For more information, see "[Setting team creation permissions](https://help.github.com/en/articles/setting-team-creation-permissions-in-your-organization)."
+     *
+     * When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of `maintainers`. For more information, see "[About teams](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+     */
+    create: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["create"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["create"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    createDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates a new discussion post on a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * This endpoint triggers [notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/about-notifications). Creating content too quickly using this endpoint may result in abuse rate limiting. See "[Abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#abuse-rate-limits)" and "[Dealing with abuse rate limits](https://docs.github.com/enterprise-server@3.0/rest/guides/best-practices-for-integrators#dealing-with-rate-limits)" for details.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `POST /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    createDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["createDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Deletes a comment on a team discussion. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    deleteDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Delete a discussion from a team's page. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    deleteDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["deleteDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To delete a team, the authenticated user must be an organization owner or team maintainer.
+     *
+     * If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}`.
+     */
+    deleteInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["deleteInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["deleteInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Gets a team using the team's `slug`. GitHub Enterprise Server generates the `slug` from the team `name`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}`.
+     */
+    getByName: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getByName"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["getByName"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific comment on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    getDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Get a specific discussion on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    getDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To get a user's membership with a team, the team must be visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     *
+     * **Note:**
+     * The response contains the `state` of the membership and the member's `role`.
+     *
+     * The `role` for organization owners is set to `maintainer`. For more information about `maintainer` roles, see see [Create a team](https://docs.github.com/enterprise-server@3.0/rest/reference/teams#create-a-team).
+     */
+    getMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["getMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all teams in an organization that are visible to the authenticated user.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the child teams of the team specified by `{team_slug}`.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/teams`.
+     */
+    listChildInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listChildInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listChildInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all comments on a team discussion. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments`.
+     */
+    listDiscussionCommentsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionCommentsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all discussions on a team's page. OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions`.
+     */
+    listDiscussionsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listDiscussionsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * List all of the teams across all of the organizations to which the authenticated user belongs. This method requires `user`, `repo`, or `read:org` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) when authenticating via [OAuth](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/).
+     */
+    listForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team members will include the members of child teams.
+     *
+     * To list members in a team, the team must be visible to the authenticated user.
+     */
+    listMembersInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listMembersInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listMembersInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the organization projects for a team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/projects`.
+     */
+    listProjectsInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listProjectsInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists a team's repositories visible to the authenticated user.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/repos`.
+     */
+    listReposInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["listReposInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["listReposInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Team synchronization is available for organizations using GitHub Enterprise Cloud. For more information, see [GitHub's products](https://help.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
+     *
+     * To remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. Removing team membership does not delete the user, it just removes their membership from the team.
+     *
+     * **Note:** When you have team synchronization set up for a team with your organization's identity provider (IdP), you will see an error if you attempt to use the API for making changes to the team's membership. If you have access to manage group membership in your IdP, you can manage GitHub Enterprise Server team membership through your identity provider, which automatically adds and removes team members in an organization. For more information, see "[Synchronizing teams between your identity provider and GitHub Enterprise Server](https://help.github.com/articles/synchronizing-teams-between-your-identity-provider-and-github/)."
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/memberships/{username}`.
+     */
+    removeMembershipForUserInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeMembershipForUserInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes an organization project from a team. An organization owner or a team maintainer can remove any project from the team. To remove a project from a team as an organization member, the authenticated user must have `read` access to both the team and project, or `admin` access to the team or project. This endpoint removes the project from the team, but does not delete the project.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/projects/{project_id}`.
+     */
+    removeProjectInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeProjectInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is an organization owner or a team maintainer, they can remove any repositories from the team. To remove a repository from a team as an organization member, the authenticated user must have admin access to the repository and must be able to see the team. This does not delete the repository, it just removes it from the team.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `DELETE /organizations/{org_id}/team/{team_id}/repos/{owner}/{repo}`.
+     */
+    removeRepoInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["removeRepoInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the body text of a discussion comment. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}/comments/{comment_number}`.
+     */
+    updateDiscussionCommentInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionCommentInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Edits the title and body text of a discussion post. Only the parameters you provide are updated. OAuth access tokens require the `write:discussion` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}/discussions/{discussion_number}`.
+     */
+    updateDiscussionInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["teams"]["updateDiscussionInOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * To edit a team, the authenticated user must either be an organization owner or a team maintainer.
+     *
+     * **Note:** You can also specify a team by `org_id` and `team_id` using the route `PATCH /organizations/{org_id}/team/{team_id}`.
+     */
+    updateInOrg: {
+      (
+        params?: RestEndpointMethodTypes["teams"]["updateInOrg"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["teams"]["updateInOrg"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  users: {
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    addEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["addEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+
+    checkPersonIsFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["checkPersonIsFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a GPG key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Adds a public SSH key to the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth, or OAuth with at least `write:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    createPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["createPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * This endpoint is accessible with the `user` scope.
+     */
+    deleteEmailForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteEmailForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a GPG key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deleteGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deleteGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Removes a public SSH key from the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `admin:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    deletePublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["deletePublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Note that you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#http-verbs)."
+     *
+     * Following a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    follow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["follow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["follow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * If the authenticated user is authenticated through basic authentication or OAuth with the `user` scope, then the response lists public and private profile information.
+     *
+     * If the authenticated user is authenticated through OAuth without the `user` scope, then the response lists only public profile information.
+     */
+    getAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides publicly available information about someone with a GitHub account.
+     *
+     * GitHub Apps with the `Plan` user permission can use this endpoint to retrieve information about a user's GitHub Enterprise Server plan. The GitHub App must be authenticated as a user. See "[Identifying and authorizing users for GitHub Apps](https://docs.github.com/enterprise-server@3.0/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)" for details about authentication. For an example response, see 'Response with GitHub Enterprise Server plan information' below"
+     *
+     * The `email` key in the following response is the publicly visible email address from your GitHub Enterprise Server [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be “public” which provides an email entry for this endpoint. If you do not set a public email address for `email`, then it will have a value of `null`. You only see publicly visible email addresses when authenticated with GitHub Enterprise Server. For more information, see [Authentication](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#authentication).
+     *
+     * The Emails API enables you to list all of your email addresses, and toggle a primary email to be visible publicly. For more information, see "[Emails API](https://docs.github.com/enterprise-server@3.0/rest/reference/users#emails)".
+     */
+    getByUsername: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getByUsername"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["getByUsername"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Provides hovercard information when authenticated through basic auth or OAuth with the `repo` scope. You can find out more about someone in relation to their pull requests, issues, repositories, and organizations.
+     *
+     * The `subject_type` and `subject_id` parameters provide context for the person's hovercard, which returns more information than without the parameters. For example, if you wanted to find out more about `octocat` who owns the `Spoon-Knife` repository via cURL, it would look like this:
+     *
+     * ```shell
+     *  curl -u username:token
+     *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
+     * ```
+     */
+    getContextForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getContextForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getContextForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single GPG key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getGpgKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getGpgKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * View extended details for a single public SSH key. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    getPublicSshKeyForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["getPublicSshKeyForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all users, in the order that they signed up on GitHub Enterprise Server. This list includes personal user accounts and organization accounts.
+     *
+     * Note: Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.0/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of users.
+     */
+    list: {
+      (
+        params?: RestEndpointMethodTypes["users"]["list"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["list"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists all of your email addresses, and specifies which one is visible to the public. This endpoint is accessible with the `user:email` scope.
+     */
+    listEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the authenticated user follows.
+     */
+    listFollowedByAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowedByAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the authenticated user.
+     */
+    listFollowersForAuthenticatedUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForAuthenticatedUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people following the specified user.
+     */
+    listFollowersForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowersForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowersForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the people who the specified user follows.
+     */
+    listFollowingForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listFollowingForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listFollowingForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the current user's GPG keys. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:gpg_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listGpgKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the GPG keys for a user. This information is accessible by anyone.
+     */
+    listGpgKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listGpgKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists your publicly visible email address, which you can set with the [Set primary email visibility for the authenticated user](https://docs.github.com/enterprise-server@3.0/rest/reference/users#set-primary-email-visibility-for-the-authenticated-user) endpoint. This endpoint is accessible with the `user:email` scope.
+     */
+    listPublicEmailsForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicEmailsForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the _verified_ public SSH keys for a user. This is accessible by anyone.
+     */
+    listPublicKeysForUser: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicKeysForUser"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Lists the public SSH keys for the authenticated user's GitHub account. Requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/enterprise-server@3.0/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+     */
+    listPublicSshKeysForAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["listPublicSshKeysForAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Unfollowing a user requires the user to be logged in and authenticated with basic auth or OAuth with the `user:follow` scope.
+     */
+    unfollow: {
+      (
+        params?: RestEndpointMethodTypes["users"]["unfollow"]["parameters"]
+      ): Promise<RestEndpointMethodTypes["users"]["unfollow"]["response"]>;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * **Note:** If your email is set to private and you send an `email` parameter as part of this request to update your profile, your privacy settings are still enforced: the email address will not be displayed on your public profile or via the API.
+     */
+    updateAuthenticated: {
+      (
+        params?: RestEndpointMethodTypes["users"]["updateAuthenticated"]["parameters"]
+      ): Promise<
+        RestEndpointMethodTypes["users"]["updateAuthenticated"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,52 +7,72 @@ import { endpointsToMethods } from "./endpoints-to-methods";
 
 import ENDPOINTS_220 from "./generated/ghe-220-endpoints";
 import ADMIN_ENDPOINTS_220 from "./generated/ghe-220-admin-endpoints";
+import { RestEndpointMethods as RestEndpointMethods_220 } from "./generated/ghe-220-method-types";
 
 import ENDPOINTS_221 from "./generated/ghe-221-endpoints";
 import ADMIN_ENDPOINTS_221 from "./generated/ghe-221-admin-endpoints";
+import { RestEndpointMethods as RestEndpointMethods_221 } from "./generated/ghe-221-method-types";
 
 import ENDPOINTS_222 from "./generated/ghe-222-endpoints";
 import ADMIN_ENDPOINTS_222 from "./generated/ghe-222-admin-endpoints";
+import { RestEndpointMethods as RestEndpointMethods_222 } from "./generated/ghe-222-method-types";
 
 import ENDPOINTS_30 from "./generated/ghe-30-endpoints";
 import ADMIN_ENDPOINTS_30 from "./generated/ghe-30-admin-endpoints";
+import { RestEndpointMethods as RestEndpointMethods_30 } from "./generated/ghe-30-method-types";
 
-export function enterpriseServer220Admin(octokit: Octokit) {
+export function enterpriseServer220Admin(octokit: Octokit): {
+  enterpriseAdmin: RestEndpointMethods_220["enterpriseAdmin"];
+} {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ADMIN_ENDPOINTS_220);
 }
 enterpriseServer220Admin.VERSION = VERSION;
 
-export function enterpriseServer220(octokit: Octokit) {
+export function enterpriseServer220(octokit: Octokit): RestEndpointMethods_220 {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ENDPOINTS_220);
 }
 enterpriseServer220.VERSION = VERSION;
 
-export function enterpriseServer221Admin(octokit: Octokit) {
+export function enterpriseServer221Admin(octokit: Octokit): {
+  enterpriseAdmin: RestEndpointMethods_221["enterpriseAdmin"];
+} {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ADMIN_ENDPOINTS_221);
 }
 enterpriseServer221Admin.VERSION = VERSION;
 
-export function enterpriseServer221(octokit: Octokit) {
+export function enterpriseServer221(octokit: Octokit): RestEndpointMethods_221 {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ENDPOINTS_221);
 }
 enterpriseServer221.VERSION = VERSION;
 
-export function enterpriseServer222Admin(octokit: Octokit) {
+export function enterpriseServer222Admin(octokit: Octokit): {
+  enterpriseAdmin: RestEndpointMethods_222["enterpriseAdmin"];
+} {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ADMIN_ENDPOINTS_222);
 }
 enterpriseServer222Admin.VERSION = VERSION;
 
-export function enterpriseServer222(octokit: Octokit) {
+export function enterpriseServer222(octokit: Octokit): RestEndpointMethods_222 {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ENDPOINTS_222);
 }
 enterpriseServer222.VERSION = VERSION;
 
-export function enterpriseServer30Admin(octokit: Octokit) {
+export function enterpriseServer30Admin(octokit: Octokit): {
+  enterpriseAdmin: RestEndpointMethods_30["enterpriseAdmin"];
+} {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ADMIN_ENDPOINTS_30);
 }
 enterpriseServer30Admin.VERSION = VERSION;
 
-export function enterpriseServer30(octokit: Octokit) {
+export function enterpriseServer30(octokit: Octokit): RestEndpointMethods_30 {
+  // @ts-ignore - not worth the hassle
   return endpointsToMethods(octokit, ENDPOINTS_30);
 }
 enterpriseServer30.VERSION = VERSION;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,14 @@
 import { Route, RequestParameters } from "@octokit/types";
 
-type EndpointDecorations = {
+import { RestEndpointMethods } from "./generated/method-types";
+
+export type EndpointDecorations = {
+  mapToData?: string;
   deprecated?: string;
   renamed?: [string, string];
+  renamedParameters?: {
+    [name: string]: string;
+  };
 };
 
 export type EndpointsDefaultsAndDecorations = {


### PR DESCRIPTION
fixes #84

- [x] generate types
- [ ] add types for enterprise-admin endpoints

We currently only maintain the Endpoint types for api.github.com in [`@octokit/types/src/generated/Endpoints.ts`](https://github.com/octokit/types.ts/blob/0bca341cdc2d0d8d629593ca8b98b3b226fe851b/src/generated/Endpoints.ts). Ideally we would start generating endpoint types for all GHES versions and GHAE, but that will be a bigger effort. For the time being it might be worth to figure out a workaround to unblock this pull request
