### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           version: ${{ matrix.node_version }}
+          cache: npm
       - run: npm ci
       - run: npx jest --coverage
 

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           version: 12
+          cache: npm
       - run: npm ci
       - run: "npm run lint:fix"
       - uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,6 +20,8 @@ jobs:
           # make sure that other actions get triggered when using `git push` in gr2m/create-or-update-pull-request-action
           token: ${{ secrets.OCTOKITBOT_PAT }}
       - uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       # try checking out routes-update branch. Ignore error if it does not exist
       - run: git checkout routes-update || true
@@ -29,7 +31,8 @@ jobs:
 
       # if update is coming from octokit/openapi, use the version from event
       - run: npm run update-endpoints
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'octokit/openapi release'
+        if: github.event_name == 'repository_dispatch' && github.event.action ==
+          'octokit/openapi release'
         env:
           VERSION: ${{ github.event.client_payload.release.tag_name }}
 
@@ -41,12 +44,16 @@ jobs:
 
       # if event is coming from octokit/types.ts, update @octokit/types to latest version and get OpenAPI version from its package.json
       - run: npm install @octokit/types@latest
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'octokit/types.ts release'
-      - run: node -e "console.log('::set-output name=version::' + require('@octokit/types/package').octokit['openapi-version'])"
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'octokit/types.ts release'
+        if: github.event_name == 'repository_dispatch' && github.event.action ==
+          'octokit/types.ts release'
+      - run: node -e "console.log('::set-output name=version::' +
+          require('@octokit/types/package').octokit['openapi-version'])"
+        if: github.event_name == 'repository_dispatch' && github.event.action ==
+          'octokit/types.ts release'
         id: openapi_types
       - run: npm run update-endpoints
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'octokit/types.ts release'
+        if: github.event_name == 'repository_dispatch' && github.event.action ==
+          'octokit/types.ts release'
         env:
           VERSION: ${{ steps.openapi_types.outputs.version }}
 


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
