### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Besides the admin-specific endpoints, there are differences between `api.github.
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-enterprise-server` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/plugin-enterprise-server` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
-  import { enterpriseServer220Admin } from "https://cdn.skypack.dev/@octokit/plugin-enterprise-server";
+  import { Octokit } from "https://esm.sh/@octokit/core";
+  import { enterpriseServer220Admin } from "https://esm.sh/@octokit/plugin-enterprise-server";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.