### PR TITLE
refactor: use `node:` specifier imports and full relative import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
           "tsconfig": "test/tsconfig.test.json"
         }
       ]
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/update-endpoints/code.js
+++ b/scripts/update-endpoints/code.js
@@ -76,7 +76,7 @@ async function generateRoutes() {
     writeFileSync(
       ALL_ENDPOINTS_PATH,
       await prettier.format(
-        `import type { EndpointsDefaultsAndDecorations } from "../types";
+        `import type { EndpointsDefaultsAndDecorations } from "../types.js";
     const Endpoints: EndpointsDefaultsAndDecorations = ${JSON.stringify(
       sortKeys(newRoutes, { deep: true })
     )}
@@ -94,7 +94,7 @@ async function generateRoutes() {
     writeFileSync(
       ADMIN_ENDPOINTS_PATH,
       await prettier.format(
-        `import type { EndpointsDefaultsAndDecorations } from "../types";
+        `import type { EndpointsDefaultsAndDecorations } from "../types.js";
     const Endpoints: EndpointsDefaultsAndDecorations = ${JSON.stringify(
       sortKeys({ enterpriseAdmin: newRoutes.enterpriseAdmin }, { deep: true })
     )}
@@ -108,8 +108,8 @@ async function generateRoutes() {
     const INDEX_PATH = pathResolve(process.cwd(), `src/index.ts`);
     const imports = GHE_VERSIONS.map(
       (version) => `
-        import ENDPOINTS_${version} from "./generated/ghe-${version}-endpoints";
-        import ADMIN_ENDPOINTS_${version} from "./generated/ghe-${version}-admin-endpoints";
+        import ENDPOINTS_${version} from "./generated/ghe-${version}-endpoints.js";
+        import ADMIN_ENDPOINTS_${version} from "./generated/ghe-${version}-admin-endpoints.js";
       `
     ).join("\n");
     const methods = GHE_VERSIONS.map(
@@ -132,8 +132,8 @@ async function generateRoutes() {
 
         import { Octokit } from "@octokit/core";
 
-        import { VERSION } from "./version";
-        import { endpointsToMethods } from "./endpoints-to-methods";
+        import { VERSION } from "./version.js";
+        import { endpointsToMethods } from "./endpoints-to-methods.js";
 
         ${imports}
 

--- a/src/endpoints-to-methods.ts
+++ b/src/endpoints-to-methods.ts
@@ -6,7 +6,7 @@ import type {
   Route,
   Url,
 } from "@octokit/types";
-import type { EndpointsDefaultsAndDecorations } from "./types";
+import type { EndpointsDefaultsAndDecorations } from "./types.js";
 
 type EndpointMethods = {
   [methodName: string]: typeof Octokit.prototype.request;

--- a/src/generated/ghe-310-admin-endpoints.ts
+++ b/src/generated/ghe-310-admin-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   enterpriseAdmin: {
     addAuthorizedSshKey: ["POST {origin}/setup/api/settings/authorized-keys"],

--- a/src/generated/ghe-310-endpoints.ts
+++ b/src/generated/ghe-310-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [

--- a/src/generated/ghe-37-admin-endpoints.ts
+++ b/src/generated/ghe-37-admin-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   enterpriseAdmin: {
     addAuthorizedSshKey: ["POST {origin}/setup/api/settings/authorized-keys"],

--- a/src/generated/ghe-37-endpoints.ts
+++ b/src/generated/ghe-37-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [

--- a/src/generated/ghe-38-admin-endpoints.ts
+++ b/src/generated/ghe-38-admin-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   enterpriseAdmin: {
     addAuthorizedSshKey: ["POST {origin}/setup/api/settings/authorized-keys"],

--- a/src/generated/ghe-38-endpoints.ts
+++ b/src/generated/ghe-38-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [

--- a/src/generated/ghe-39-admin-endpoints.ts
+++ b/src/generated/ghe-39-admin-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   enterpriseAdmin: {
     addAuthorizedSshKey: ["POST {origin}/setup/api/settings/authorized-keys"],

--- a/src/generated/ghe-39-endpoints.ts
+++ b/src/generated/ghe-39-endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,20 @@
 
 import { Octokit } from "@octokit/core";
 
-import { VERSION } from "./version";
-import { endpointsToMethods } from "./endpoints-to-methods";
+import { VERSION } from "./version.js";
+import { endpointsToMethods } from "./endpoints-to-methods.js";
 
-import ENDPOINTS_37 from "./generated/ghe-37-endpoints";
-import ADMIN_ENDPOINTS_37 from "./generated/ghe-37-admin-endpoints";
+import ENDPOINTS_37 from "./generated/ghe-37-endpoints.js";
+import ADMIN_ENDPOINTS_37 from "./generated/ghe-37-admin-endpoints.js";
 
-import ENDPOINTS_38 from "./generated/ghe-38-endpoints";
-import ADMIN_ENDPOINTS_38 from "./generated/ghe-38-admin-endpoints";
+import ENDPOINTS_38 from "./generated/ghe-38-endpoints.js";
+import ADMIN_ENDPOINTS_38 from "./generated/ghe-38-admin-endpoints.js";
 
-import ENDPOINTS_39 from "./generated/ghe-39-endpoints";
-import ADMIN_ENDPOINTS_39 from "./generated/ghe-39-admin-endpoints";
+import ENDPOINTS_39 from "./generated/ghe-39-endpoints.js";
+import ADMIN_ENDPOINTS_39 from "./generated/ghe-39-admin-endpoints.js";
 
-import ENDPOINTS_310 from "./generated/ghe-310-endpoints";
-import ADMIN_ENDPOINTS_310 from "./generated/ghe-310-admin-endpoints";
+import ENDPOINTS_310 from "./generated/ghe-310-endpoints.js";
+import ADMIN_ENDPOINTS_310 from "./generated/ghe-310-admin-endpoints.js";
 
 export function enterpriseServer37Admin(octokit: Octokit) {
   return endpointsToMethods(octokit, ADMIN_ENDPOINTS_37);

--- a/test/enterprise-server.test.ts
+++ b/test/enterprise-server.test.ts
@@ -1,7 +1,7 @@
 import fetchMock from "fetch-mock";
 import { Octokit } from "@octokit/core";
 
-import { enterpriseServer38Admin } from "../src";
+import { enterpriseServer38Admin } from "../src/index.ts";
 
 describe("enterpriseCloud plugin", () => {
   it("README example", async () => {

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { enterpriseServer38, enterpriseServer38Admin } from "../src";
+import { enterpriseServer38, enterpriseServer38Admin } from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("enterpriseServer35 is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.